### PR TITLE
add high-level Library wrapper …

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -261,8 +261,7 @@ private:
 
 /**
  * Locates a dynamic library with the supplied library name and dynamically
- * loads it into the caller's address space.  If the library contains a D
- * runtime it will be integrated with the current runtime.
+ * loads it into the caller's address space.
  *
  * Params:
  *  name = The name of the dynamic library to load.
@@ -315,9 +314,7 @@ void* loadLibrary()(in char[] name)
 }
 
 /**
- * Unloads the dynamic library referenced by p.  If this library contains a
- * D runtime then any necessary finalization or cleanup of that runtime
- * will be performed.
+ * Unloads the dynamic library referenced by p.
  *
  * Params:
  *  p = A reference to the library to unload.

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -512,13 +512,13 @@ private mixin template LibraryImpl(alias dlsym)
 
     T loadFunc(T:FT*, string fqn, FT)() if(is(FT == function))
     {
-        static const mangling = mangleFunc!(T)(fqn);
+        static const mangling = mangleFunc!(T)(fqn) ~ '\0';
         return cast(T)dlsym(handle, mangling.ptr);
     }
 
     typeof(func)* loadFunc(alias func)() if (is(typeof(func) == function))
     {
-        static const mangling = func.mangleof;
+        static const mangling = func.mangleof ~ '\0';
         return cast(typeof(func)*)dlsym(handle, mangling.ptr);
     }
 
@@ -531,13 +531,13 @@ private mixin template LibraryImpl(alias dlsym)
 
     T* loadVar(T, string fqn)()
     {
-        static const mangling = mangle!(T)(fqn);
+        static const mangling = mangle!(T)(fqn) ~ '\0';
         return cast(T*)dlsym(handle, mangling.ptr);
     }
 
     typeof(var)* loadVar(alias var)() if (!is(typeof(var) == function) && hasLinkage!var)
     {
-        static const mangling = var.mangleof;
+        static const mangling = var.mangleof ~ '\0';
         return cast(typeof(var)*)dlsym(handle, mangling.ptr);
     }
 

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -355,7 +355,18 @@ else version (Windows)
     struct Library
     {
         import core.sys.windows.windows : GetProcAddress;
-        mixin LibraryImpl!GetProcAddress;
+        version (Win32)
+        {
+            // Workaround Bug 3956. Optlink strips leading underscores
+            // of exported symbols. Except for the first one :(.
+            export __gshared uint _dummy; // So that's the first one hopefully.
+            mixin LibraryImpl!(function(h, n) =>
+                GetProcAddress(h, n[0] == '_' && n[1] == 'D' ? n+1 : n));
+        }
+        else
+        {
+            mixin LibraryImpl!GetProcAddress;
+        }
     }
 }
 else version (Posix)

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -22,7 +22,7 @@ extern (C) void* rt_loadLibrary(const char* name);
 /// ditto
 version (Windows) extern (C) void* rt_loadLibraryW(const wchar_t* name);
 /// C interface for Runtime.unloadLibrary
-extern (C) bool  rt_unloadLibrary(void* ptr);
+extern (C) int rt_unloadLibrary(void* ptr);
 
 private
 {
@@ -227,7 +227,7 @@ struct Runtime
      */
     static bool unloadLibrary()(void* p)
     {
-        return rt_unloadLibrary(p);
+        return !!rt_unloadLibrary(p);
     }
 
 

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -476,7 +476,21 @@ else version (Posix)
 {
     struct Library
     {
-        import core.sys.posix.dlfcn : dlsym;
+        version (Shared)
+        {
+            // Wrap dlsym in a D function to keep any dependency on
+            // libdl within druntime.
+            private static void* dlsym(void* handle, const char* name)
+            {
+                import core.sys.posix.dlfcn : dlsym;
+                return dlsym(handle, name);
+            }
+        }
+        else
+        {
+            private static void* dlsym(void* handle, const char* name);
+        }
+
         mixin LibraryImpl!dlsym;
     }
 }

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -259,21 +259,42 @@ private:
     __gshared ModuleUnitTester sm_moduleUnitTester = null;
 }
 
-/**
- * Locates a dynamic library with the supplied library name and dynamically
- * loads it into the caller's address space.
- *
- * Params:
- *  name = The name of the dynamic library to load.
- *
- * Returns:
- *  A reference to the library or null on error.
- */
-void* loadLibrary()(in char[] name)
+version (CoreDdoc)
+    version = UseDecls;
+else version (Windows)
+{}
+else version (Shared)
+{}
+else
+    version = UseDecls;
+
+version (UseDecls)
 {
-    import core.stdc.stdlib : free, malloc;
-    version (Windows)
+    /**
+     * Locates a dynamic library with the supplied library name and dynamically
+     * loads it into the caller's address space.
+     *
+     * Params:
+     *  name = The name of the dynamic library to load.
+     *
+     * Returns:
+     *  A reference to the library or null on error.
+     */
+    void* loadLibrary(in char[] name);
+
+    /**
+     * Unloads the dynamic library referenced by p.
+     *
+     * Params:
+     *  p = A reference to the library to unload.
+     */
+    bool unloadLibrary(void* p);
+}
+else version (Windows)
+{
+    void* loadLibrary(in char[] name)
     {
+        import core.stdc.stdlib : free, malloc;
         import core.sys.windows.windows;
 
         if (name.length == 0) return null;
@@ -297,8 +318,17 @@ void* loadLibrary()(in char[] name)
 
         return rt_loadLibraryW(buf);
     }
-    else version (Posix)
+
+    bool unloadLibrary(void* p)
     {
+        return !!rt_unloadLibrary(p);
+    }
+}
+else version (Shared)
+{
+    void* loadLibrary(in char[] name)
+    {
+        import core.stdc.stdlib : free, malloc;
         /* Need a 0-terminated C string for the dll name
          */
         immutable len = name.length;
@@ -311,17 +341,11 @@ void* loadLibrary()(in char[] name)
 
         return rt_loadLibrary(buf);
     }
-}
 
-/**
- * Unloads the dynamic library referenced by p.
- *
- * Params:
- *  p = A reference to the library to unload.
- */
-bool unloadLibrary()(void* p)
-{
-    return !!rt_unloadLibrary(p);
+    bool unloadLibrary(void* p)
+    {
+        return !!rt_unloadLibrary(p);
+    }
 }
 
 

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -124,7 +124,7 @@ version (Windows)
      *      true    succeeded
      *      false   some failure happened
      */
-    extern (C) bool rt_unloadLibrary(void* ptr)
+    extern (C) int rt_unloadLibrary(void* ptr)
     {
         gcClrFn gcClr  = cast(gcClrFn) GetProcAddress(ptr, "gc_clrProxy");
         if (gcClr !is null)

--- a/src/rt/sections_linux.d
+++ b/src/rt/sections_linux.d
@@ -466,7 +466,7 @@ version (Shared)
         return handle;
     }
 
-    extern(C) bool rt_unloadLibrary(void* handle)
+    extern(C) int rt_unloadLibrary(void* handle)
     {
         if (handle is null) return false;
 

--- a/test/shared/src/lib.d
+++ b/test/shared/src/lib.d
@@ -1,3 +1,5 @@
+module lib;
+
 // test EH
 void throwException()
 {
@@ -14,12 +16,12 @@ Exception collectException(void delegate() dg)
 }
 
 // test GC
-__gshared Object root;
+private __gshared Object root;
 void alloc() { root = new Object(); }
 void access() { assert(root.toString() !is null); } // vtbl call will fail if finalized
 void free() { root = null; }
 
-Object tls_root;
+private Object tls_root;
 void tls_alloc() { tls_root = new Object(); }
 void tls_access() { assert(tls_root.toString() !is null); } // vtbl call will fail if finalized
 void tls_free() { tls_root = null; }

--- a/test/shared/src/lib.di
+++ b/test/shared/src/lib.di
@@ -1,0 +1,28 @@
+// D import file generated from 'lib.d'
+module lib;
+void throwException();
+Exception collectException(void delegate() dg);
+private __gshared Object root;
+
+
+void alloc();
+void access();
+void free();
+private Object tls_root;
+
+void tls_alloc();
+void tls_access();
+void tls_free();
+shared
+{
+	uint shared_static_ctor;
+	uint shared_static_dtor;
+	uint static_ctor;
+	uint static_dtor;
+}
+//no link dependency, the loading will initialize the lib
+//shared static this();
+//static this();
+extern (C) int runTests();
+
+void runTestsImpl();

--- a/test/shared/src/libloaddep.d
+++ b/test/shared/src/libloaddep.d
@@ -8,7 +8,7 @@ extern(C) int runDepTests(const char* name)
     {
         auto lib = .loadLib(name[0 .. strlen(name)]);
         scope (exit) lib.unloadLib();
-        auto runTests = lib.loadFunc!(RunTests, "runTests")();
+        auto runTests = lib.findFunc!(RunTests, "runTests")();
         if (runTests !is null && runTests())
             return true;
     }

--- a/test/shared/src/libloaddep.d
+++ b/test/shared/src/libloaddep.d
@@ -4,10 +4,16 @@ extern(C) alias RunTests = int function();
 
 extern(C) int runDepTests(const char* name)
 {
-    auto lib = .loadLib(name[0 .. strlen(name)]);
-    if (!lib) return false;
-    auto runTests = lib.loadFunc!(RunTests, "runTests")();
-    assert(runTests !is null);
-    if (!runTests()) return false;
-    return lib.unloadLib();
+    try
+    {
+        auto lib = .loadLib(name[0 .. strlen(name)]);
+        scope (exit) lib.unloadLib();
+        auto runTests = lib.loadFunc!(RunTests, "runTests")();
+        if (runTests !is null && runTests())
+            return true;
+    }
+    catch (Exception)
+    {
+    }
+    return false;
 }

--- a/test/shared/src/libloaddep.d
+++ b/test/shared/src/libloaddep.d
@@ -1,13 +1,13 @@
-import core.runtime, core.sys.posix.dlfcn;
+import core.runtime, core.stdc.string, core.sys.posix.dlfcn;
 
 extern(C) alias RunTests = int function();
 
 extern(C) int runDepTests(const char* name)
 {
-    auto h = rt_loadLibrary(name);
-    if (h is null) return false;
-    auto runTests = cast(RunTests).dlsym(h, "runTests");
+    auto lib = .loadLibrary(name[0 .. strlen(name)]);
+    if (lib is null) return false;
+    auto runTests = lib.loadFunc!(RunTests, "runTests")();
     assert(runTests !is null);
     if (!runTests()) return false;
-    return rt_unloadLibrary(h);
+    return lib.unloadLibrary();
 }

--- a/test/shared/src/libloaddep.d
+++ b/test/shared/src/libloaddep.d
@@ -4,10 +4,10 @@ extern(C) alias RunTests = int function();
 
 extern(C) int runDepTests(const char* name)
 {
-    auto lib = .loadLibrary(name[0 .. strlen(name)]);
-    if (lib is null) return false;
+    auto lib = .loadLib(name[0 .. strlen(name)]);
+    if (!lib) return false;
     auto runTests = lib.loadFunc!(RunTests, "runTests")();
     assert(runTests !is null);
     if (!runTests()) return false;
-    return lib.unloadLibrary();
+    return lib.unloadLib();
 }

--- a/test/shared/src/load.d
+++ b/test/shared/src/load.d
@@ -7,7 +7,7 @@ void loadSym(T)(void* handle, ref T val, const char* mangle)
 
 void* openLib(string s)
 {
-    auto h = Runtime.loadLibrary(s);
+    auto h = .loadLibrary(s);
     assert(h !is null);
 
     loadSym(h, libThrowException, "_D3lib14throwExceptionFZv");
@@ -30,7 +30,7 @@ void* openLib(string s)
 
 void closeLib(void* h)
 {
-    Runtime.unloadLibrary(h);
+    .unloadLibrary(h);
 }
 
 __gshared

--- a/test/shared/src/load.d
+++ b/test/shared/src/load.d
@@ -1,29 +1,27 @@
 import core.runtime, core.stdc.stdio, core.thread, core.sys.linux.dlfcn;
 
-void loadSym(T)(void* handle, ref T val, const char* mangle)
-{
-    val = cast(T).dlsym(handle, mangle);
-}
-
-void* openLib(string s)
+Library openLib(string s)
 {
     auto h = .loadLibrary(s);
     assert(h !is null);
 
-    loadSym(h, libThrowException, "_D3lib14throwExceptionFZv");
-    loadSym(h, libCollectException, "_D3lib16collectExceptionFDFZvZC9Exception");
+    import lib; // .di
 
-    loadSym(h, libAlloc, "_D3lib5allocFZv");
-    loadSym(h, libTlsAlloc, "_D3lib9tls_allocFZv");
-    loadSym(h, libAccess, "_D3lib6accessFZv");
-    loadSym(h, libTlsAccess, "_D3lib10tls_accessFZv");
-    loadSym(h, libFree, "_D3lib4freeFZv");
-    loadSym(h, libTlsFree, "_D3lib8tls_freeFZv");
+    libThrowException = h.loadFunc!throwException();
+    libCollectException = h.loadFunc!collectException();
 
-    loadSym(h, libSharedStaticCtor, "_D3lib18shared_static_ctorOk");
-    loadSym(h, libSharedStaticDtor, "_D3lib18shared_static_dtorOk");
-    loadSym(h, libStaticCtor, "_D3lib11static_ctorOk");
-    loadSym(h, libStaticDtor, "_D3lib11static_dtorOk");
+    libAlloc = h.loadFunc!alloc();
+    libAccess = h.loadFunc!access();
+    libFree = h.loadFunc!free();
+
+    libTlsAlloc = h.loadFunc!tls_alloc();
+    libTlsAccess = h.loadFunc!tls_access();
+    libTlsFree = h.loadFunc!tls_free();
+
+    libSharedStaticCtor = h.loadVar!shared_static_ctor();
+    libSharedStaticDtor = h.loadVar!shared_static_dtor();
+    libStaticCtor = h.loadVar!static_ctor();
+    libStaticDtor = h.loadVar!static_dtor();
 
     return h;
 }

--- a/test/shared/src/load.d
+++ b/test/shared/src/load.d
@@ -2,8 +2,8 @@ import core.runtime, core.stdc.stdio, core.thread, core.sys.linux.dlfcn;
 
 Library openLib(string s)
 {
-    auto h = .loadLibrary(s);
-    assert(h !is null);
+    auto h = .loadLib(s);
+    assert(h);
 
     import lib; // .di
 
@@ -26,9 +26,9 @@ Library openLib(string s)
     return h;
 }
 
-void closeLib(void* h)
+void closeLib(Library lib)
 {
-    .unloadLibrary(h);
+    .unloadLib(lib);
 }
 
 __gshared

--- a/test/shared/src/load.d
+++ b/test/shared/src/load.d
@@ -6,21 +6,21 @@ Library openLib(string s)
 
     import lib; // .di
 
-    libThrowException = h.loadFunc!throwException();
-    libCollectException = h.loadFunc!collectException();
+    libThrowException = h.findFunc!throwException();
+    libCollectException = h.findFunc!collectException();
 
-    libAlloc = h.loadFunc!alloc();
-    libAccess = h.loadFunc!access();
-    libFree = h.loadFunc!free();
+    libAlloc = h.findFunc!alloc();
+    libAccess = h.findFunc!access();
+    libFree = h.findFunc!free();
 
-    libTlsAlloc = h.loadFunc!tls_alloc();
-    libTlsAccess = h.loadFunc!tls_access();
-    libTlsFree = h.loadFunc!tls_free();
+    libTlsAlloc = h.findFunc!tls_alloc();
+    libTlsAccess = h.findFunc!tls_access();
+    libTlsFree = h.findFunc!tls_free();
 
-    libSharedStaticCtor = h.loadVar!shared_static_ctor();
-    libSharedStaticDtor = h.loadVar!shared_static_dtor();
-    libStaticCtor = h.loadVar!static_ctor();
-    libStaticDtor = h.loadVar!static_dtor();
+    libSharedStaticCtor = h.findVar!shared_static_ctor();
+    libSharedStaticDtor = h.findVar!shared_static_dtor();
+    libStaticCtor = h.findVar!static_ctor();
+    libStaticDtor = h.findVar!static_dtor();
 
     return h;
 }

--- a/test/shared/src/load.d
+++ b/test/shared/src/load.d
@@ -3,7 +3,6 @@ import core.runtime, core.stdc.stdio, core.thread, core.sys.linux.dlfcn;
 Library openLib(string s)
 {
     auto h = .loadLib(s);
-    assert(h);
 
     import lib; // .di
 

--- a/test/shared/src/load_linkdep.d
+++ b/test/shared/src/load_linkdep.d
@@ -1,4 +1,4 @@
-import core.runtime, core.sys.posix.dlfcn;
+import core.runtime;
 
 extern(C) alias RunDepTests = int function();
 
@@ -8,9 +8,9 @@ void main(string[] args)
     assert(name[$-13 .. $] == "/load_linkdep");
     name = name[0 .. $-12] ~ "liblinkdep.so";
 
-    auto h = .loadLibrary(name);
-    assert(h);
-    auto runDepTests = cast(RunDepTests)dlsym(h, "runDepTests");
+    auto lib = .loadLibrary(name);
+    assert(lib);
+    auto runDepTests = lib.loadFunc!(RunDepTests, "runDepTests")();
     assert(runDepTests());
-    assert(.unloadLibrary(h));
+    assert(lib.unloadLibrary());
 }

--- a/test/shared/src/load_linkdep.d
+++ b/test/shared/src/load_linkdep.d
@@ -8,9 +8,9 @@ void main(string[] args)
     assert(name[$-13 .. $] == "/load_linkdep");
     name = name[0 .. $-12] ~ "liblinkdep.so";
 
-    auto lib = .loadLibrary(name);
+    auto lib = .loadLib(name);
     assert(lib);
     auto runDepTests = lib.loadFunc!(RunDepTests, "runDepTests")();
     assert(runDepTests());
-    assert(lib.unloadLibrary());
+    assert(lib.unloadLib());
 }

--- a/test/shared/src/load_linkdep.d
+++ b/test/shared/src/load_linkdep.d
@@ -8,9 +8,9 @@ void main(string[] args)
     assert(name[$-13 .. $] == "/load_linkdep");
     name = name[0 .. $-12] ~ "liblinkdep.so";
 
-    auto h = Runtime.loadLibrary(name);
+    auto h = .loadLibrary(name);
     assert(h);
     auto runDepTests = cast(RunDepTests)dlsym(h, "runDepTests");
     assert(runDepTests());
-    assert(Runtime.unloadLibrary(h));
+    assert(.unloadLibrary(h));
 }

--- a/test/shared/src/load_linkdep.d
+++ b/test/shared/src/load_linkdep.d
@@ -9,8 +9,7 @@ void main(string[] args)
     name = name[0 .. $-12] ~ "liblinkdep.so";
 
     auto lib = .loadLib(name);
-    assert(lib);
+    scope (exit) lib.unloadLib();
     auto runDepTests = lib.loadFunc!(RunDepTests, "runDepTests")();
     assert(runDepTests());
-    assert(lib.unloadLib());
 }

--- a/test/shared/src/load_linkdep.d
+++ b/test/shared/src/load_linkdep.d
@@ -10,6 +10,6 @@ void main(string[] args)
 
     auto lib = .loadLib(name);
     scope (exit) lib.unloadLib();
-    auto runDepTests = lib.loadFunc!(RunDepTests, "runDepTests")();
+    auto runDepTests = lib.findFunc!(RunDepTests, "runDepTests")();
     assert(runDepTests());
 }

--- a/test/shared/src/load_loaddep.d
+++ b/test/shared/src/load_loaddep.d
@@ -8,6 +8,6 @@ void main(string[] args)
     auto libloaddep = root ~ "libloaddep.so";
     auto lib = .loadLib(libloaddep);
     scope (exit) lib.unloadLib();
-    auto runDepTests = lib.loadFunc!(RunDepTests, "runDepTests")();
+    auto runDepTests = lib.findFunc!(RunDepTests, "runDepTests")();
     assert(runDepTests((root ~ "lib.so\0").ptr));
 }

--- a/test/shared/src/load_loaddep.d
+++ b/test/shared/src/load_loaddep.d
@@ -1,4 +1,4 @@
-import core.runtime, core.sys.posix.dlfcn;
+import core.runtime;
 
 extern(C) alias RunDepTests = int function(const char*);
 
@@ -6,8 +6,8 @@ void main(string[] args)
 {
     auto root = args[0][0..$-"load_loaddep".length];
     auto libloaddep = root ~ "libloaddep.so";
-    auto h = .loadLibrary(libloaddep);
-    auto runDepTests = cast(RunDepTests)dlsym(h, "runDepTests");
+    auto lib = .loadLibrary(libloaddep);
+    auto runDepTests = lib.loadFunc!(RunDepTests, "runDepTests")();
     assert(runDepTests((root ~ "lib.so\0").ptr));
-    assert(.unloadLibrary(h));
+    assert(lib.unloadLibrary());
 }

--- a/test/shared/src/load_loaddep.d
+++ b/test/shared/src/load_loaddep.d
@@ -6,8 +6,8 @@ void main(string[] args)
 {
     auto root = args[0][0..$-"load_loaddep".length];
     auto libloaddep = root ~ "libloaddep.so";
-    auto h = Runtime.loadLibrary(libloaddep);
+    auto h = .loadLibrary(libloaddep);
     auto runDepTests = cast(RunDepTests)dlsym(h, "runDepTests");
     assert(runDepTests((root ~ "lib.so\0").ptr));
-    assert(Runtime.unloadLibrary(h));
+    assert(.unloadLibrary(h));
 }

--- a/test/shared/src/load_loaddep.d
+++ b/test/shared/src/load_loaddep.d
@@ -6,8 +6,8 @@ void main(string[] args)
 {
     auto root = args[0][0..$-"load_loaddep".length];
     auto libloaddep = root ~ "libloaddep.so";
-    auto lib = .loadLibrary(libloaddep);
+    auto lib = .loadLib(libloaddep);
     auto runDepTests = lib.loadFunc!(RunDepTests, "runDepTests")();
     assert(runDepTests((root ~ "lib.so\0").ptr));
-    assert(lib.unloadLibrary());
+    assert(lib.unloadLib());
 }

--- a/test/shared/src/load_loaddep.d
+++ b/test/shared/src/load_loaddep.d
@@ -7,7 +7,7 @@ void main(string[] args)
     auto root = args[0][0..$-"load_loaddep".length];
     auto libloaddep = root ~ "libloaddep.so";
     auto lib = .loadLib(libloaddep);
+    scope (exit) lib.unloadLib();
     auto runDepTests = lib.loadFunc!(RunDepTests, "runDepTests")();
     assert(runDepTests((root ~ "lib.so\0").ptr));
-    assert(lib.unloadLib());
 }


### PR DESCRIPTION
- loadLib now returns a Library struct
- Library sub-types the native platform handle (alias this)
- Library.findFunc loads a D mangled function
- Library.findVar loads a D mangled variable

The single most annoying pull request I ever prepared. Too many long-standing unrelated bugs for such a straightforward implementation.