### PR TITLE
Add `GC.getWeakRefTarget` function.

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -120,6 +120,8 @@ private
 
     extern (C) void gc_removeRoot( in void* p ) nothrow;
     extern (C) void gc_removeRange( in void* p ) nothrow;
+
+    extern (C) void* gc_getWeakRefTarget( void** p ) nothrow;
 }
 
 
@@ -716,5 +718,23 @@ struct GC
     static void removeRange( in void* p ) nothrow /* FIXME pure */
     {
         gc_removeRange( p );
+    }
+
+    /*
+    Undocumented until we have a finished weak reference implementation
+    where it may be an internal function.
+
+    Returns referenced object if it isn't finalized thus
+    creating a strong reference to it.
+    Returns null otherwise.
+
+    $(D p) is assumed to be set to null on finalization.
+
+    Params:
+     p = A pointer into a GC-managed memory block or null.
+    */
+    static inout(void)* getWeakRefTarget( ref shared inout void* p ) nothrow /* FIXME pure */
+    {
+        return cast(inout(void)*) gc_getWeakRefTarget( cast(void**) &p );
     }
 }

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -40,6 +40,7 @@ import gc.os;
 
 import cstdlib = core.stdc.stdlib : calloc, free, malloc, realloc;
 import core.stdc.string;
+import core.atomic;
 import core.bitop;
 import core.sync.mutex;
 static import core.memory;
@@ -1264,6 +1265,22 @@ class GC
         stats.poolsize = psize;
         stats.usedsize = bsize - flsize;
         stats.freelistsize = flsize;
+    }
+
+    /**
+    Returns referenced object if it isn't finalized thus
+    creating a strong reference to it.
+    Returns null otherwise.
+
+    `*p` is assumed to be set to null on finalization.
+    */
+    void* getWeakRefTarget(void** pp)
+    {
+        // `atomicLoad` is used to prevent compiler optimizations.
+        void* p = cast(void*) atomicLoad(*cast(shared) pp);
+        gcLock.lock();
+        gcLock.unlock();
+        return atomicLoad(*cast(shared) pp) ? p : null;
     }
 }
 

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -62,6 +62,7 @@ private
 
             void function(void*) gc_removeRoot;
             void function(void*) gc_removeRange;
+            void* function(void**) gc_getWeakRefTarget;
         }
     }
 
@@ -97,6 +98,7 @@ private
 
         pthis.gc_removeRoot = &gc_removeRoot;
         pthis.gc_removeRange = &gc_removeRange;
+        pthis.gc_getWeakRefTarget = &gc_getWeakRefTarget;
     }
 }
 
@@ -313,6 +315,13 @@ extern (C)
         if( proxy is null )
             return _gc.removeRange( p );
         return proxy.gc_removeRange( p );
+    }
+
+    void* gc_getWeakRefTarget( void** p )
+    {
+        if( proxy is null )
+            return _gc.getWeakRefTarget( p );
+        return proxy.gc_getWeakRefTarget( p );
     }
 
     Proxy* gc_getProxy()


### PR DESCRIPTION
A basic functionality for weak reference implementation. We want to be able to do things like this:
```D
if(!atomicLoad(weakPtr)) // fast check
	return null;
return GC.getWeakRefTarget(weakPtr);
```