### PR TITLE
core.stdc.fenv: proper support for Microsoft C Runtime (Visual Studio >= 2013)

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -273,9 +273,9 @@ else
 }
 
 ///
-void feraiseexcept(int excepts);
+int feraiseexcept(int excepts);
 ///
-void feclearexcept(int excepts);
+int feclearexcept(int excepts);
 
 ///
 int fetestexcept(int excepts);
@@ -283,9 +283,9 @@ int fetestexcept(int excepts);
 int feholdexcept(fenv_t* envp);
 
 ///
-void fegetexceptflag(fexcept_t* flagp, int excepts);
+int fegetexceptflag(fexcept_t* flagp, int excepts);
 ///
-void fesetexceptflag(in fexcept_t* flagp, int excepts);
+int fesetexceptflag(in fexcept_t* flagp, int excepts);
 
 ///
 int fegetround();
@@ -293,8 +293,8 @@ int fegetround();
 int fesetround(int round);
 
 ///
-void fegetenv(fenv_t* envp);
+int fegetenv(fenv_t* envp);
 ///
-void fesetenv(in fenv_t* envp);
+int fesetenv(in fenv_t* envp);
 ///
-void feupdateenv(in fenv_t* envp);
+int feupdateenv(in fenv_t* envp);

--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -24,10 +24,6 @@ version( MinGW )
 version( linux )
     version = GNUFP;
 
-version( DigitalMars )
-    version( Win32 )
-        version = DMC_RUNTIME;
-
 version( GNUFP )
 {
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/x86/fpu/bits/fenv.h
@@ -114,7 +110,7 @@ version( GNUFP )
         static assert(0, "Unimplemented architecture");
     }
 }
-else version( DMC_RUNTIME )
+else version( CRuntime_DigitalMars )
 {
     struct fenv_t
     {
@@ -125,9 +121,8 @@ else version( DMC_RUNTIME )
     }
     alias fexcept_t = int;
 }
-else version( Windows )
+else version( CRuntime_Microsoft )
 {
-    // MSVCRT
     struct fenv_t
     {
         uint ctl;
@@ -231,28 +226,22 @@ enum
     FE_TOWARDZERO   = 0xC00, ///
 }
 
-version( DMC_RUNTIME )
+version( GNUFP )
+{
+    ///
+    enum FE_DFL_ENV = cast(fenv_t*)(-1);
+}
+else version( CRuntime_DigitalMars )
 {
     private extern __gshared fenv_t _FE_DFL_ENV;
     ///
     enum fenv_t* FE_DFL_ENV = &_FE_DFL_ENV;
 }
-else version( Windows )
+else version( CRuntime_Microsoft )
 {
-    version( MinGW )
-        ///
-        enum FE_DFL_ENV = cast(fenv_t*)(-1);
-    else
-    {
-        private immutable fenv_t _Fenv0 = {0, 0};
-        ///
-        enum FE_DFL_ENV = &_Fenv0;
-    }
-}
-else version( linux )
-{
+    private immutable fenv_t _Fenv0 = {0, 0};
     ///
-    enum FE_DFL_ENV = cast(fenv_t*)(-1);
+    enum FE_DFL_ENV = &_Fenv0;
 }
 else version( OSX )
 {


### PR DESCRIPTION
VCRT 2013 uses a minimally different <tt>feraiseexcept()</tt> implementation than this one from VCRT 2014 CTP 3 (2013 additionally sets the exception flags via <tt>fesetexceptflag</tt>), but I guess that doesn't make a huge difference. The rest of 2013 is identical to 2014, so MSVC 2013 should be supported too.
More important are the correct constants and the implementation of 2 inline functions (to prevent linking errors).