### PR TITLE
core.stdc.stdio: prepare for MSVCRT 14 (VS 2015) support

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -965,12 +965,12 @@ else version( CRuntime_Microsoft )
     enum _TWO_DIGIT_EXPONENT = 1;
 
     ///
-    int _filbuf(FILE *fp);
+    int _filbuf(_iobuf* fp);
     ///
-    int _flsbuf(int c, FILE *fp);
+    int _flsbuf(int c, _iobuf* fp);
 
     ///
-    int _fputc_nolock(int c, FILE *fp)
+    int _fputc_nolock(int c, _iobuf* fp)
     {
         fp._cnt = fp._cnt - 1;
         if (fp._cnt >= 0)
@@ -984,7 +984,7 @@ else version( CRuntime_Microsoft )
     }
 
     ///
-    int _fgetc_nolock(FILE *fp)
+    int _fgetc_nolock(_iobuf* fp)
     {
         fp._cnt = fp._cnt - 1;
         if (fp._cnt >= 0)

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -259,7 +259,7 @@ version( CRuntime_DigitalMars )
 else version( CRuntime_Microsoft )
 {
     ///
-    alias int fpos_t; //check this
+    alias long fpos_t;
 
     ///
     struct _iobuf

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -949,7 +949,17 @@ else version( CRuntime_Microsoft )
     ///
     pure int  fileno(FILE* stream)   { return stream._file;                              }
   }
-  ///
+
+  version( None ) // requires MSVCRT >= 14 (VS 2015)
+  {
+    ///
+    int snprintf(char* s, size_t n, in char* fmt, ...);
+    ///
+    int vsnprintf(char* s, size_t n, in char* format, va_list arg);
+  }
+  else
+  {
+    ///
     int   _snprintf(char* s, size_t n, in char* fmt, ...);
     ///
     alias _snprintf snprintf;
@@ -996,6 +1006,7 @@ else version( CRuntime_Microsoft )
         else
             return _filbuf(fp);
     }
+  }
 
     ///
     int _lock_file(FILE *fp);


### PR DESCRIPTION
Once MSVC 2014 is required, things will get easier, for example here because they now provide a standard-conformant <tt>(v)snprintf()</tt> implementation (except for x87 support), see [this MSDN blog](http://blogs.msdn.com/b/vcblog/archive/2014/06/18/crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1.aspx).
Additionally, <tt>_fputc_nolock()</tt> and <tt>_fgetc_nolock()</tt> are no longer defined as macros, but available in the library, just like any other supported C runtime.