### PR TITLE
update deprecation of MAP_ANON from core.sys.posix.sys.mman

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -42,12 +42,15 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\freebsd\dlfcn.d \
 	$(IMPDIR)\core\sys\freebsd\execinfo.d \
+	\
+	$(IMPDIR)\core\sys\freebsd\sys\cdefs.d \
 	$(IMPDIR)\core\sys\freebsd\sys\elf.d \
 	$(IMPDIR)\core\sys\freebsd\sys\elf_common.d \
 	$(IMPDIR)\core\sys\freebsd\sys\elf32.d \
 	$(IMPDIR)\core\sys\freebsd\sys\elf64.d \
 	$(IMPDIR)\core\sys\freebsd\sys\event.d \
 	$(IMPDIR)\core\sys\freebsd\sys\link_elf.d \
+	$(IMPDIR)\core\sys\freebsd\sys\mman.d \
 	$(IMPDIR)\core\sys\freebsd\time.d \
 	\
 	$(IMPDIR)\core\sys\linux\config.d \
@@ -68,6 +71,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\osx\execinfo.d \
 	$(IMPDIR)\core\sys\osx\pthread.d \
+	\
 	$(IMPDIR)\core\sys\osx\mach\dyld.d \
 	$(IMPDIR)\core\sys\osx\mach\getsect.d \
 	$(IMPDIR)\core\sys\osx\mach\kern_return.d \
@@ -75,6 +79,9 @@ COPY=\
 	$(IMPDIR)\core\sys\osx\mach\port.d \
 	$(IMPDIR)\core\sys\osx\mach\semaphore.d \
 	$(IMPDIR)\core\sys\osx\mach\thread_act.d \
+	\
+	$(IMPDIR)\core\sys\osx\sys\cdefs.d \
+	$(IMPDIR)\core\sys\osx\sys\mman.d \
 	\
 	$(IMPDIR)\core\sys\posix\arpa\inet.d \
 	$(IMPDIR)\core\sys\posix\config.d \

--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -71,12 +71,14 @@ MANIFEST=\
 	src\core\sys\freebsd\execinfo.d \
 	src\core\sys\freebsd\time.d \
 	\
+	src\core\sys\freebsd\sys\cdefs.d \
 	src\core\sys\freebsd\sys\elf.d \
 	src\core\sys\freebsd\sys\elf_common.d \
 	src\core\sys\freebsd\sys\elf32.d \
 	src\core\sys\freebsd\sys\elf64.d \
 	src\core\sys\freebsd\sys\event.d \
 	src\core\sys\freebsd\sys\link_elf.d \
+	src\core\sys\freebsd\sys\mman.d \
 	\
 	src\core\sys\linux\config.d \
 	src\core\sys\linux\dlfcn.d \
@@ -105,6 +107,9 @@ MANIFEST=\
 	src\core\sys\osx\mach\port.d \
 	src\core\sys\osx\mach\semaphore.d \
 	src\core\sys\osx\mach\thread_act.d \
+	\
+	src\core\sys\osx\sys\cdefs.d \
+	src\core\sys\osx\sys\mman.d \
 	\
 	src\core\sys\posix\config.d \
 	src\core\sys\posix\dirent.d \

--- a/src/core/sys/freebsd/sys/cdefs.d
+++ b/src/core/sys/freebsd/sys/cdefs.d
@@ -1,0 +1,16 @@
+/**
+ * D header file for FreeBSD
+ *
+ * Authors: Martin Nowak
+ */
+module core.sys.freebsd.sys.cdefs;
+
+version (FreeBSD):
+
+public import core.sys.posix.config;
+
+// https://svnweb.freebsd.org/base/head/sys/sys/cdefs.h?revision=271155&view=markup
+enum __POSIX_VISIBLE = 200112;
+enum __XSI_VISIBLE = 700;
+enum __BSD_VISIBLE = true;
+enum __ISO_C_VISIBLE = 1999;

--- a/src/core/sys/freebsd/sys/mman.d
+++ b/src/core/sys/freebsd/sys/mman.d
@@ -1,0 +1,145 @@
+/**
+ * D header file for FreeBSD
+ *
+ * Authors: Martin Nowak
+ */
+module core.sys.freebsd.sys.mman;
+
+version (FreeBSD):
+extern (C):
+nothrow:
+
+public import core.sys.posix.sys.mman;
+import core.sys.freebsd.sys.cdefs;
+import core.sys.posix.sys.types;
+// https://svnweb.freebsd.org/base/head/sys/sys/mman.h?revision=270825&view=markup
+
+static if (__BSD_VISIBLE)
+{
+    enum INHERIT_SHARE = 0;
+    enum INHERIT_COPY = 1;
+    enum INHERIT_NONE = 2;
+}
+
+// already in core.sys.posix.sys.mman
+// enum PROT_NONE = 0x00;
+// enum PROT_READ = 0x01;
+// enum PROT_WRITE = 0x02;
+// enum PROT_EXEC = 0x04;
+// enum MAP_SHARED = 0x0001;
+// enum MAP_PRIVATE = 0x0002;
+static if (__BSD_VISIBLE)
+    alias MAP_COPY = MAP_PRIVATE;
+// enum MAP_FIXED = 0x0010;
+
+static if (__BSD_VISIBLE)
+{
+    enum MAP_RENAME = 0x0020;
+    enum MAP_NORESERVE = 0x0040;
+    enum MAP_RESERVED0080 = 0x0080;
+    enum MAP_RESERVED0100 = 0x0100;
+    enum MAP_HASSEMAPHORE = 0x0200;
+    enum MAP_STACK = 0x0400;
+    enum MAP_NOSYNC = 0x0800;
+
+    enum MAP_FILE = 0x0000;
+}
+    // cannot be within __BSD_VISIBLE because of forward reference (Bugzilla 11301)
+    enum MAP_ANON = 0x1000;
+static if (__BSD_VISIBLE)
+{
+    //#ifndef _KERNEL
+    alias MAP_ANONYMOUS = MAP_ANON;
+    //#endif /* !_KERNEL */
+
+    enum MAP_EXCL = 0x00004000;
+    enum MAP_NOCORE = 0x00020000;
+    enum MAP_PREFAULT_READ = 0x00040000;
+    version (LP64)
+        enum MAP_32BIT = 0x00080000;
+
+
+    extern(D) int MAP_ALIGNED(int n) { return n << MAP_ALIGNMENT_SHIFT; }
+    enum MAP_ALIGNMENT_SHIFT = 24;
+    enum MAP_ALIGNMENT_MASK = MAP_ALIGNED(0xff);
+    enum MAP_ALIGNED_SUPER = MAP_ALIGNED(1);
+}
+
+static if (__POSIX_VISIBLE >= 199309)
+{
+    // already in core.sys.posix.sys.mman
+    // enum MCL_CURRENT = 0x0001;
+    // enum MCL_FUTURE = 0x0002;
+}
+
+// already in core.sys.posix.sys.mman
+enum MAP_FAILED = cast(void*)-1;
+
+// already in core.sys.posix.sys.mman
+// enum MS_SYNC = 0x0000;
+// enum MS_ASYNC = 0x0001;
+// enum MS_INVALIDATE = 0x0002;
+
+enum _MADV_NORMAL = 0;
+enum _MADV_RANDOM = 1;
+enum _MADV_SEQUENTIAL = 2;
+enum _MADV_WILLNEED = 3;
+enum _MADV_DONTNEED = 4;
+
+static if (__BSD_VISIBLE)
+{
+    alias MADV_NORMAL = _MADV_NORMAL;
+    alias MADV_RANDOM = _MADV_RANDOM;
+    alias MADV_SEQUENTIAL = _MADV_SEQUENTIAL;
+    alias MADV_WILLNEED = _MADV_WILLNEED;
+    alias MADV_DONTNEED = _MADV_DONTNEED;
+    enum MADV_FREE = 5;
+    enum MADV_NOSYNC = 6;
+    enum MADV_AUTOSYNC = 7;
+    enum MADV_NOCORE = 8;
+    enum MADV_CORE = 9;
+    enum MADV_PROTECT = 10;
+
+    enum MINCORE_INCORE = 0x1;
+    enum MINCORE_REFERENCED = 0x2;
+    enum MINCORE_MODIFIED = 0x4;
+    enum MINCORE_REFERENCED_OTHER = 0x8;
+    enum MINCORE_MODIFIED_OTHER = 0x10;
+    enum MINCORE_SUPER = 0x20;
+
+    enum SHM_ANON = cast(const(char) *)1;
+}
+
+static if (__POSIX_VISIBLE >= 200112)
+{
+    // already in core.sys.posix.sys.mman
+    // alias POSIX_MADV_NORMAL = _MADV_NORMAL;
+    // alias POSIX_MADV_RANDOM = _MADV_RANDOM;
+    // alias POSIX_MADV_SEQUENTIAL = _MADV_SEQUENTIAL;
+    // alias POSIX_MADV_WILLNEED = _MADV_WILLNEED;
+    // alias POSIX_MADV_DONTNEED = _MADV_DONTNEED;
+}
+
+static if (__BSD_VISIBLE)
+{
+    int getpagesizes(size_t *, int);
+    int madvise(void *, size_t, int);
+    int mincore(const(void) *, size_t, char *);
+    int minherit(void *, size_t, int);
+}
+// already in core.sys.posix.sys.mman
+// int mlock(const void *, size_t);
+// void *  mmap(void *, size_t, int, int, int, off_t);
+// int mprotect(const void *, size_t, int);
+// int msync(void *, size_t, int);
+// int munlock(const void *, size_t);
+// int munmap(void *, size_t);
+static if (__POSIX_VISIBLE >= 200112)
+    // int posix_madvise(void *, size_t, int);
+static if (__POSIX_VISIBLE >= 199309)
+{
+    // int mlockall(int);
+    // int munlockall();
+    // int shm_open(const(char) *, int, mode_t);
+    // int shm_unlink(const(char) *);
+}

--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -649,20 +649,10 @@ else
     static if (__USE_MISC) enum
     {
         MAP_FILE = 0,
-        //MAP_ANONYMOUS = __MAP_ANONYMOUS,
-        //MAP_ANON = MAP_ANONYMOUS,
-        MAP_HUGE_SHIFT = 26,
-        MAP_HUGE_MASK = 0x3f,
-    }
-
-    /* This should be behind the static if (__USE_MISC), but it runs into
-     * trouble with the alias declaration for MAP_ANON in core.sys.posix.sys.mman
-     * due to forward reference problems. See Bugzilla 11301 for a fuller explanation.
-     */
-    enum
-    {
         MAP_ANONYMOUS = __MAP_ANONYMOUS,
         MAP_ANON = MAP_ANONYMOUS,
+        MAP_HUGE_SHIFT = 26,
+        MAP_HUGE_MASK = 0x3f,
     }
 
     // in core.sys.posix.sys.mman

--- a/src/core/sys/osx/sys/cdefs.d
+++ b/src/core/sys/osx/sys/cdefs.d
@@ -1,0 +1,16 @@
+/**
+ * D header file for OSX
+ *
+ * Authors: Martin Nowak
+ */
+module core.sys.osx.sys.cdefs;
+
+version (OSX):
+
+public import core.sys.posix.config;
+
+// http://www.opensource.apple.com/source/xnu/xnu-2422.115.4/bsd/sys/cdefs.h
+enum _DARWIN_C_SOURCE = true;
+
+enum __DARWIN_C_FULL = 900000L;
+enum __DARWIN_C_LEVEL = __DARWIN_C_FULL;

--- a/src/core/sys/osx/sys/mman.d
+++ b/src/core/sys/osx/sys/mman.d
@@ -1,0 +1,105 @@
+/**
+ * D header file for FreeBSD
+ *
+ * Authors: Martin Nowak
+ */
+module core.sys.osx.sys.mman;
+
+version (OSX):
+extern (C):
+nothrow:
+
+public import core.sys.posix.sys.mman;
+import core.sys.osx.sys.cdefs;
+import core.sys.posix.sys.types;
+
+// already in core.sys.posix.sys.mman
+// enum PROT_NONE = 0x00;
+// enum PROT_READ = 0x01;
+// enum PROT_WRITE = 0x02;
+// enum PROT_EXEC = 0x04;
+
+// already in core.sys.posix.sys.mman
+// enum MAP_SHARED = 0x0001;
+// enum MAP_PRIVATE = 0x0002;
+static if (_DARWIN_C_SOURCE)
+    alias MAP_COPY = MAP_PRIVATE;
+// enum MAP_FIXED = 0x0010;
+
+static if (_DARWIN_C_SOURCE)
+{
+     enum MAP_RENAME = 0x0020;
+     enum MAP_NORESERVE = 0x0040;
+     enum MAP_RESERVED0080 = 0x0080;
+     enum MAP_NOEXTEND = 0x0100;
+     enum MAP_HASSEMAPHORE = 0x0200;
+     enum MAP_NOCACHE = 0x0400;
+     enum MAP_JIT = 0x0800;
+}
+
+// already in core.sys.posix.sys.mman
+// enum MCL_CURRENT = 0x0001;
+// enum MCL_FUTURE = 0x0002;
+
+// enum MAP_FAILED = cast(void*)-1;
+
+// enum MS_ASYNC = 0x0001;
+// enum MS_INVALIDATE = 0x0002;
+// enum MS_SYNC = 0x0010;
+
+static if (_DARWIN_C_SOURCE)
+{
+    enum MS_KILLPAGES = 0x0004;
+    enum MS_DEACTIVATE = 0x0008;
+
+    enum MAP_FILE = 0x0000;
+}
+    // cannot be within _DARWIN_C_SOURCE because of forward reference (Bugzilla 11301)
+    enum MAP_ANON = 0x1000;
+
+// already in core.sys.posix.sys.mman
+// enum POSIX_MADV_NORMAL = 0;
+// enum POSIX_MADV_RANDOM = 1;
+// enum POSIX_MADV_SEQUENTIAL = 2;
+// enum POSIX_MADV_WILLNEED = 3;
+// enum POSIX_MADV_DONTNEED = 4;
+
+static if (_DARWIN_C_SOURCE)
+{
+    alias MADV_NORMAL = POSIX_MADV_NORMAL;
+    alias MADV_RANDOM = POSIX_MADV_RANDOM;
+    alias MADV_SEQUENTIAL = POSIX_MADV_SEQUENTIAL;
+    alias MADV_WILLNEED = POSIX_MADV_WILLNEED;
+    alias MADV_DONTNEED = POSIX_MADV_DONTNEED;
+    enum MADV_FREE = 5;
+    enum MADV_ZERO_WIRED_PAGES = 6;
+    enum MADV_FREE_REUSABLE = 7;
+    enum MADV_FREE_REUSE = 8;
+    enum MADV_CAN_REUSE = 9;
+
+    enum MINCORE_INCORE = 0x1;
+    enum MINCORE_REFERENCED = 0x2;
+    enum MINCORE_MODIFIED = 0x4;
+    enum MINCORE_REFERENCED_OTHER = 0x8;
+    enum MINCORE_MODIFIED_OTHER = 0x10;
+}
+
+// already in core.sys.posix.sys.mman
+// int mlockall(int);
+// int munlockall(void);
+// int mlock(const void *, size_t);
+// void *  mmap(void *, size_t, int, int, int, off_t);
+// int mprotect(void *, size_t, int);
+// int msync(void *, size_t, int);
+// int munlock(const void *, size_t);
+// int munmap(void *, size_t);
+// int shm_open(const char *, int, ...);
+// int shm_unlink(const char *);
+// int posix_madvise(void *, size_t, int);
+
+static if (_DARWIN_C_SOURCE)
+{
+    int madvise(void *, size_t, int);
+    int mincore(const(void)*, size_t, char *);
+    int minherit(void *, size_t, int);
+}

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -202,10 +202,6 @@ version( linux )
     enum MAP_PRIVATE    = 0x02;
     enum MAP_FIXED      = 0x10;
 
-    static import core.sys.linux.sys.mman;
-    deprecated("Please use core.sys.linux.sys.mman for non-POSIX extensions")
-    alias MAP_ANON = core.sys.linux.sys.mman.MAP_ANON;
-
     enum MAP_FAILED     = cast(void*) -1;
 
     version (Alpha) enum
@@ -240,7 +236,9 @@ else version( OSX )
     enum MAP_SHARED     = 0x0001;
     enum MAP_PRIVATE    = 0x0002;
     enum MAP_FIXED      = 0x0010;
-    enum MAP_ANON       = 0x1000; // non-standard
+    static import core.sys.osx.sys.mman;
+    deprecated("Please use core.sys.osx.sys.mman for non-POSIX extensions")
+    alias MAP_ANON = core.sys.osx.sys.mman.MAP_ANON;
 
     enum MAP_FAILED     = cast(void*)-1;
 
@@ -255,7 +253,9 @@ else version( FreeBSD )
     enum MAP_SHARED     = 0x0001;
     enum MAP_PRIVATE    = 0x0002;
     enum MAP_FIXED      = 0x0010;
-    enum MAP_ANON       = 0x1000; // non-standard
+    static import core.sys.freebsd.sys.mman;
+    deprecated("Please use core.sys.freebsd.sys.mman for non-POSIX extensions")
+    alias MAP_ANON = core.sys.freebsd.sys.mman.MAP_ANON;
 
     enum MAP_FAILED     = cast(void*)-1;
 

--- a/win32.mak
+++ b/win32.mak
@@ -270,6 +270,9 @@ $(IMPDIR)\core\sys\freebsd\execinfo.d : src\core\sys\freebsd\execinfo.d
 $(IMPDIR)\core\sys\freebsd\time.d : src\core\sys\freebsd\time.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\freebsd\sys\cdefs.d : src\core\sys\freebsd\sys\cdefs.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\freebsd\sys\elf.d : src\core\sys\freebsd\sys\elf.d
 	copy $** $@
 
@@ -286,6 +289,9 @@ $(IMPDIR)\core\sys\freebsd\sys\event.d : src\core\sys\freebsd\sys\event.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\freebsd\sys\link_elf.d : src\core\sys\freebsd\sys\link_elf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\freebsd\sys\mman.d : src\core\sys\freebsd\sys\mman.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\config.d : src\core\sys\linux\config.d
@@ -355,6 +361,12 @@ $(IMPDIR)\core\sys\osx\mach\semaphore.d : src\core\sys\osx\mach\semaphore.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\osx\mach\thread_act.d : src\core\sys\osx\mach\thread_act.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\osx\sys\cdefs.d : src\core\sys\osx\sys\cdefs.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\osx\sys\mman.d : src\core\sys\osx\sys\mman.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\arpa\inet.d : src\core\sys\posix\arpa\inet.d

--- a/win64.mak
+++ b/win64.mak
@@ -277,6 +277,9 @@ $(IMPDIR)\core\sys\freebsd\execinfo.d : src\core\sys\freebsd\execinfo.d
 $(IMPDIR)\core\sys\freebsd\time.d : src\core\sys\freebsd\time.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\freebsd\sys\cdefs.d : src\core\sys\freebsd\sys\cdefs.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\freebsd\sys\elf.d : src\core\sys\freebsd\sys\elf.d
 	copy $** $@
 
@@ -293,6 +296,9 @@ $(IMPDIR)\core\sys\freebsd\sys\event.d : src\core\sys\freebsd\sys\event.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\freebsd\sys\link_elf.d : src\core\sys\freebsd\sys\link_elf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\freebsd\sys\mman.d : src\core\sys\freebsd\sys\mman.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\config.d : src\core\sys\linux\config.d
@@ -354,6 +360,7 @@ $(IMPDIR)\core\sys\osx\mach\kern_return.d : src\core\sys\osx\mach\kern_return.d
 
 $(IMPDIR)\core\sys\osx\mach\loader.d : src\core\sys\osx\mach\loader.d
 	copy $** $@
+
 $(IMPDIR)\core\sys\osx\mach\port.d : src\core\sys\osx\mach\port.d
 	copy $** $@
 
@@ -361,6 +368,12 @@ $(IMPDIR)\core\sys\osx\mach\semaphore.d : src\core\sys\osx\mach\semaphore.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\osx\mach\thread_act.d : src\core\sys\osx\mach\thread_act.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\osx\sys\cdefs.d : src\core\sys\osx\sys\cdefs.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\osx\sys\mman.d : src\core\sys\osx\sys\mman.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\arpa\inet.d : src\core\sys\posix\arpa\inet.d


### PR DESCRIPTION
- remove MAP_ANON for linux from core.sys.posix.sys.mman
  (has been deprecated since sep 2013)
    
- add platform specific headers for mman (OSX, FreeBSD)
  and deprecate MAP_ANON for those in the posix header
