### PR TITLE
Clean up unnecessary version(Posix) and version(OS) and try to more narrowly scope catch-all else blocks

### DIFF
--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -843,7 +843,7 @@ bool hasCPUID()
 {
     version(D_InlineAsm_X86_64)
         return true;
-    else
+    else version(D_InlineAsm_X86)
     {
         uint flags;
         asm nothrow @nogc {

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -493,7 +493,7 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null )
                     //       mangled function names.
                     static enum FIRSTFRAME = 5;
                 }
-                else
+                else version( Windows )
                 {
                     // NOTE: On Windows, the number of frames to exclude is based on
                     //       whether the exception is user or system-generated, so
@@ -646,7 +646,7 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null )
         {
             static enum FIRSTFRAME = 4;
         }
-        else
+        else version (Win32)
         {
             static enum FIRSTFRAME = 0;
         }

--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -53,7 +53,7 @@ version( Windows )
     alias int   c_long;
     alias uint  c_ulong;
 }
-else
+else version( Posix )
 {
   static if( (void*).sizeof > int.sizeof )
   {

--- a/src/core/stdc/signal.d
+++ b/src/core/stdc/signal.d
@@ -48,7 +48,7 @@ version( Posix )
     ///
     enum SIGTERM    = 15; // Termination
 }
-else
+else version( Windows )
 {
     ///
     enum SIG_ERR    = cast(sigfn_t) -1;

--- a/src/core/stdc/stddef.d
+++ b/src/core/stdc/stddef.d
@@ -26,7 +26,7 @@ version( Windows )
     ///
     alias wchar wchar_t;
 }
-else
+else version( Posix )
 {
     ///
     alias dchar wchar_t;

--- a/src/core/stdc/string.d
+++ b/src/core/stdc/string.d
@@ -69,12 +69,20 @@ pure char*  strstr(in char* s1, in char* s2);
 char*  strtok(char* s1, in char* s2);
 ///
 char*  strerror(int errnum);
-version (linux)
+version (CRuntime_Glibc)
 {
     ///
     const(char)* strerror_r(int errnum, char* buf, size_t buflen);
 }
-else version (Posix)
+else version (OSX)
+{
+    int strerror_r(int errnum, char* buf, size_t buflen);
+}
+else version (FreeBSD)
+{
+    int strerror_r(int errnum, char* buf, size_t buflen);
+}
+else version (CRuntime_Bionic)
 {
     ///
     int strerror_r(int errnum, char* buf, size_t buflen);

--- a/src/core/stdc/time.d
+++ b/src/core/stdc/time.d
@@ -39,7 +39,7 @@ version( Windows )
         int     tm_isdst;   /// Daylight Saving Time flag
     }
 }
-else
+else version( Posix )
 {
     ///
     struct tm
@@ -62,7 +62,7 @@ version ( Posix )
 {
     public import core.sys.posix.sys.types : time_t, clock_t;
 }
-else
+else version ( Windows )
 {
     ///
     alias c_long time_t;

--- a/src/core/sync/barrier.d
+++ b/src/core/sync/barrier.d
@@ -20,11 +20,7 @@ public import core.sync.exception;
 private import core.sync.condition;
 private import core.sync.mutex;
 
-version( Win32 )
-{
-    private import core.sys.windows.windows;
-}
-else version( Posix )
+version( Posix )
 {
     private import core.stdc.errno;
     private import core.sys.posix.pthread;

--- a/src/core/sync/rwmutex.d
+++ b/src/core/sync/rwmutex.d
@@ -21,11 +21,7 @@ private import core.sync.condition;
 private import core.sync.mutex;
 private import core.memory;
 
-version( Win32 )
-{
-    private import core.sys.windows.windows;
-}
-else version( Posix )
+version( Posix )
 {
     private import core.sys.posix.pthread;
 }

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -261,17 +261,14 @@ else
     static assert(false, "Unsupported platform");
 }
 
-version( Posix )
-{
-    int pthread_atfork(void function(), void function(), void function());
-    int pthread_attr_destroy(pthread_attr_t*);
-    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
-    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
-    int pthread_attr_init(pthread_attr_t*);
-    int pthread_attr_setdetachstate(pthread_attr_t*, int);
-    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
-    int pthread_cancel(pthread_t);
-}
+int pthread_atfork(void function(), void function(), void function());
+int pthread_attr_destroy(pthread_attr_t*);
+int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+int pthread_attr_init(pthread_attr_t*);
+int pthread_attr_setdetachstate(pthread_attr_t*, int);
+int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+int pthread_cancel(pthread_t);
 
 version( linux )
 {
@@ -424,15 +421,13 @@ else version( Android )
         }
     }
 }
-else version( Posix )
+else
 {
-    void pthread_cleanup_push(void function(void*), void*);
-    void pthread_cleanup_pop(int);
+    static assert(false, "Unsupported platform");
 }
 
-version( Posix )
+@nogc
 {
-@nogc:
     int pthread_cond_broadcast(pthread_cond_t*);
     int pthread_cond_destroy(pthread_cond_t*);
     int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;

--- a/src/core/sys/posix/sched.d
+++ b/src/core/sys/posix/sched.d
@@ -120,13 +120,10 @@ else
     static assert(false, "Unsupported platform");
 }
 
-version( Posix )
-{
-    int sched_getparam(pid_t, sched_param*);
-    int sched_getscheduler(pid_t);
-    int sched_setparam(pid_t, in sched_param*);
-    int sched_setscheduler(pid_t, int, in sched_param*);
-}
+int sched_getparam(pid_t, sched_param*);
+int sched_getscheduler(pid_t);
+int sched_setparam(pid_t, in sched_param*);
+int sched_setscheduler(pid_t, int, in sched_param*);
 
 //
 // Thread (THR)

--- a/src/core/sys/posix/semaphore.d
+++ b/src/core/sys/posix/semaphore.d
@@ -108,18 +108,15 @@ else
     static assert(false, "Unsupported platform");
 }
 
-version( Posix )
-{
-    int sem_close(sem_t*);
-    int sem_destroy(sem_t*);
-    int sem_getvalue(sem_t*, int*);
-    int sem_init(sem_t*, int, uint);
-    sem_t* sem_open(in char*, int, ...);
-    int sem_post(sem_t*);
-    int sem_trywait(sem_t*);
-    int sem_unlink(in char*);
-    int sem_wait(sem_t*);
-}
+int sem_close(sem_t*);
+int sem_destroy(sem_t*);
+int sem_getvalue(sem_t*, int*);
+int sem_init(sem_t*, int, uint);
+sem_t* sem_open(in char*, int, ...);
+int sem_post(sem_t*);
+int sem_trywait(sem_t*);
+int sem_unlink(in char*);
+int sem_wait(sem_t*);
 
 //
 // Timeouts (TMO)

--- a/src/core/sys/posix/stdio.d
+++ b/src/core/sys/posix/stdio.d
@@ -181,7 +181,7 @@ version( linux )
     off_t ftello(FILE*);
   }
 }
-else
+else version( Posix )
 {
     int   fseeko(FILE*, off_t, int);
     off_t ftello(FILE*);

--- a/src/core/sys/posix/sys/resource.d
+++ b/src/core/sys/posix/sys/resource.d
@@ -345,23 +345,33 @@ struct rlimit
     rlim_t rlim_max;
 }
 
-version (FreeBSD)
+version (CRuntime_Glibc)
+{
+    int getpriority(int, id_t);
+    int setpriority(int, id_t, int);
+}
+else version (FreeBSD)
 {
     int getpriority(int, int);
     int setpriority(int, int, int);
 }
-else version (Android)
+else version (CRuntime_Bionic)
 {
     int getpriority(int, int);
     int setpriority(int, int, int);
 }
-else
+else version (Solaris)
+{
+    int getpriority(int, id_t);
+    int setpriority(int, id_t, int);
+}
+else version (OSX)
 {
     int getpriority(int, id_t);
     int setpriority(int, id_t, int);
 }
 
-version (linux)
+version (CRuntime_Glibc)
 {
     static if (__USE_FILE_OFFSET64)
     {
@@ -377,7 +387,25 @@ version (linux)
     }
     int getrusage(int, rusage*);
 }
-else
+else version (CRuntime_Bionic)
+{
+    int getrlimit(int, rlimit*);
+    int getrusage(int, rusage*);
+    int setrlimit(int, in rlimit*);
+}
+else version (OSX)
+{
+    int getrlimit(int, rlimit*);
+    int getrusage(int, rusage*);
+    int setrlimit(int, in rlimit*);
+}
+else version (FreeBSD)
+{
+    int getrlimit(int, rlimit*);
+    int getrusage(int, rusage*);
+    int setrlimit(int, in rlimit*);
+}
+else version (Solaris)
 {
     int getrlimit(int, rlimit*);
     int getrusage(int, rusage*);

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -952,7 +952,7 @@ int    mkfifo(in char*, mode_t);
 //int    stat(in char*, stat_t*);
 mode_t umask(mode_t);
 
-version( linux )
+version( CRuntime_Glibc )
 {
   static if( __USE_LARGEFILE64 )
   {
@@ -1008,7 +1008,19 @@ else version (Solaris)
         }
     }
 }
-else version( Posix )
+else version( OSX )
+{
+    int   fstat(int, stat_t*);
+    int   lstat(in char*, stat_t*);
+    int   stat(in char*, stat_t*);
+}
+else version( FreeBSD )
+{
+    int   fstat(int, stat_t*);
+    int   lstat(in char*, stat_t*);
+    int   stat(in char*, stat_t*);
+}
+else version( CRuntime_Bionic )
 {
     int   fstat(int, stat_t*) @trusted;
     int   lstat(in char*, stat_t*);

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -24,74 +24,71 @@ extern (C):
 nothrow:
 @nogc:
 
-version( Posix )
-{
-    enum STDIN_FILENO  = 0;
-    enum STDOUT_FILENO = 1;
-    enum STDERR_FILENO = 2;
+enum STDIN_FILENO  = 0;
+enum STDOUT_FILENO = 1;
+enum STDERR_FILENO = 2;
 
-    extern __gshared char*   optarg;
-    extern __gshared int     optind;
-    extern __gshared int     opterr;
-    extern __gshared int     optopt;
+extern __gshared char*   optarg;
+extern __gshared int     optind;
+extern __gshared int     opterr;
+extern __gshared int     optopt;
 
-    int     access(in char*, int);
-    uint    alarm(uint) @trusted;
-    int     chdir(in char*);
-    int     chown(in char*, uid_t, gid_t);
-    int     close(int) @trusted;
-    size_t  confstr(int, char*, size_t);
-    int     dup(int) @trusted;
-    int     dup2(int, int) @trusted;
-    int     execl(in char*, in char*, ...);
-    int     execle(in char*, in char*, ...);
-    int     execlp(in char*, in char*, ...);
-    int     execv(in char*, in char**);
-    int     execve(in char*, in char**, in char**);
-    int     execvp(in char*, in char**);
-    void    _exit(int) @trusted;
-    int     fchown(int, uid_t, gid_t) @trusted;
-    pid_t   fork() @trusted;
-    c_long  fpathconf(int, int) @trusted;
-    //int     ftruncate(int, off_t);
-    char*   getcwd(char*, size_t);
-    gid_t   getegid() @trusted;
-    uid_t   geteuid() @trusted;
-    gid_t   getgid() @trusted;
-    int     getgroups(int, gid_t *);
-    int     gethostname(char*, size_t);
-    char*   getlogin() @trusted;
-    int     getlogin_r(char*, size_t);
-    int     getopt(int, in char**, in char*);
-    pid_t   getpgrp() @trusted;
-    pid_t   getpid() @trusted;
-    pid_t   getppid() @trusted;
-    uid_t   getuid() @trusted;
-    int     isatty(int) @trusted;
-    int     link(in char*, in char*);
-    //off_t   lseek(int, off_t, int);
-    c_long  pathconf(in char*, int);
-    int     pause() @trusted;
-    int     pipe(ref int[2]) @trusted;
-    ssize_t read(int, void*, size_t);
-    ssize_t readlink(in char*, char*, size_t);
-    int     rmdir(in char*);
-    int     setegid(gid_t) @trusted;
-    int     seteuid(uid_t) @trusted;
-    int     setgid(gid_t) @trusted;
-    int     setpgid(pid_t, pid_t) @trusted;
-    pid_t   setsid() @trusted;
-    int     setuid(uid_t) @trusted;
-    uint    sleep(uint) @trusted;
-    int     symlink(in char*, in char*);
-    c_long  sysconf(int) @trusted;
-    pid_t   tcgetpgrp(int) @trusted;
-    int     tcsetpgrp(int, pid_t) @trusted;
-    char*   ttyname(int) @trusted;
-    int     ttyname_r(int, char*, size_t);
-    int     unlink(in char*);
-    ssize_t write(int, in void*, size_t);
-}
+int     access(in char*, int);
+uint    alarm(uint) @trusted;
+int     chdir(in char*);
+int     chown(in char*, uid_t, gid_t);
+int     close(int) @trusted;
+size_t  confstr(int, char*, size_t);
+int     dup(int) @trusted;
+int     dup2(int, int) @trusted;
+int     execl(in char*, in char*, ...);
+int     execle(in char*, in char*, ...);
+int     execlp(in char*, in char*, ...);
+int     execv(in char*, in char**);
+int     execve(in char*, in char**, in char**);
+int     execvp(in char*, in char**);
+void    _exit(int) @trusted;
+int     fchown(int, uid_t, gid_t) @trusted;
+pid_t   fork() @trusted;
+c_long  fpathconf(int, int) @trusted;
+//int     ftruncate(int, off_t);
+char*   getcwd(char*, size_t);
+gid_t   getegid() @trusted;
+uid_t   geteuid() @trusted;
+gid_t   getgid() @trusted;
+int     getgroups(int, gid_t *);
+int     gethostname(char*, size_t);
+char*   getlogin() @trusted;
+int     getlogin_r(char*, size_t);
+int     getopt(int, in char**, in char*);
+pid_t   getpgrp() @trusted;
+pid_t   getpid() @trusted;
+pid_t   getppid() @trusted;
+uid_t   getuid() @trusted;
+int     isatty(int) @trusted;
+int     link(in char*, in char*);
+//off_t   lseek(int, off_t, int);
+c_long  pathconf(in char*, int);
+int     pause() @trusted;
+int     pipe(ref int[2]) @trusted;
+ssize_t read(int, void*, size_t);
+ssize_t readlink(in char*, char*, size_t);
+int     rmdir(in char*);
+int     setegid(gid_t) @trusted;
+int     seteuid(uid_t) @trusted;
+int     setgid(gid_t) @trusted;
+int     setpgid(pid_t, pid_t) @trusted;
+pid_t   setsid() @trusted;
+int     setuid(uid_t) @trusted;
+uint    sleep(uint) @trusted;
+int     symlink(in char*, in char*);
+c_long  sysconf(int) @trusted;
+pid_t   tcgetpgrp(int) @trusted;
+int     tcsetpgrp(int, pid_t) @trusted;
+char*   ttyname(int) @trusted;
+int     ttyname_r(int, char*, size_t);
+int     unlink(in char*);
+ssize_t write(int, in void*, size_t);
 
 version( linux )
 {
@@ -146,7 +143,12 @@ else version( Solaris )
         }
     }
 }
-else version( Posix )
+else version( OSX )
+{
+    off_t lseek(int, off_t, int) @trusted;
+    int   ftruncate(int, off_t) @trusted;
+}
+else version( CRuntime_Bionic )
 {
     off_t lseek(int, off_t, int) @trusted;
     int   ftruncate(int, off_t) @trusted;
@@ -815,6 +817,7 @@ else version( Android )
 
     enum _SC_PAGESIZE         = 0x0027;
     enum _SC_NPROCESSORS_ONLN = 0x0061;
+    enum _SC_THREAD_STACK_MIN = 0x004c;
 }
 else version( Solaris )
 {

--- a/src/core/sys/windows/dll.d
+++ b/src/core/sys/windows/dll.d
@@ -316,7 +316,7 @@ public:
     {
         version (Win64)
             return true;                // fixed
-        else
+        else version (Win32)
         {
         /* If the OS has allocated a TLS slot for us, we don't have to do anything
          * tls_index 0 means: the OS has not done anything, or it has allocated slot 0
@@ -398,7 +398,7 @@ public:
             return dll_process_attach( hInstance, attach_threads,
                                        null, null, null, null );
         }
-        else
+        else version (Win32)
         {
             return dll_process_attach( hInstance, attach_threads,
                                        &_tlsstart, &_tlsend, &_tls_callbacks_a, &_tls_index );

--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -47,7 +47,7 @@ public:
         {
             version(Win64)
                 static enum INTERNALFRAMES = 3;
-            else
+            else version(Win32)
                 static enum INTERNALFRAMES = 2;
 
             skip += INTERNALFRAMES; //skip the stack frames within the StackTrace class
@@ -57,7 +57,7 @@ public:
             //When a exception context is given the first stack frame is repeated for some reason
             version(Win64)
                 static enum INTERNALFRAMES = 1;
-            else
+            else version(Win32)
                 static enum INTERNALFRAMES = 1;
 
             skip += INTERNALFRAMES;
@@ -153,7 +153,7 @@ private:
                 {
                     return buffer[0..backtraceLength].dup;
                 }
-                else
+                else version(Win32)
                 {
                     auto result = new ulong[backtraceLength];
                     foreach(i, ref e; result)

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -77,7 +77,7 @@ version (Win64)
     alias  long * PLONG_PTR;
     alias ulong * PULONG_PTR;
 }
-else // Win32
+else version (Win32)
 {
     alias  int INT_PTR;
     alias uint UINT_PTR;
@@ -133,7 +133,7 @@ else // Win32
 
     version (Win64)
         alias INT_PTR function() FARPROC;
-    else
+    else version (Win32)
         alias int function() FARPROC;
 
     alias UINT_PTR WPARAM;
@@ -1311,7 +1311,7 @@ version (Win64)
         DWORD64 LastExceptionFromRip;
     }
 }
-else // Win32
+else version (Win32)
 {
     enum
     {

--- a/src/core/sys/windows/winsock2.d
+++ b/src/core/sys/windows/winsock2.d
@@ -441,7 +441,7 @@ struct servent
         char* s_proto;
         short s_port;
     }
-    else
+    else version (Win32)
     {
         short s_port;
         char* s_proto;

--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -264,7 +264,7 @@ string appendFN( string path, string name )
 
     version( Windows )
         const char sep = '\\';
-    else
+    else version( Posix )
         const char sep = '/';
 
     auto dest = path;


### PR DESCRIPTION
As mentioned on the newsgroup, this pull starts cleaning up unnecessarily separated version(OS) blocks, so that porters aren't given unneeded work.  Also, inside modules that are only available to Posix, `version(Posix)` checks are removed and catch-all uses of `else version(Posix)` are expanded to name each OS instead, as Sean said is the way it should be done.

I'm putting this pull up before it's done so that I can get comment on any of the proposed cleanups early on, before I spend time tracking more of these down.