### PR TITLE
use todo stack when traversing GC heap

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -2360,7 +2360,8 @@ struct Gcx
     private:
         void grow()
         {
-            immutable ncap = _cap ? 2 * _cap : PAGESIZE / Range.sizeof;
+            enum initSize = 64 * 1024; // Windows VirtualAlloc granularity
+            immutable ncap = _cap ? 2 * _cap : initSize / Range.sizeof;
             auto p = cast(Range*)os_mem_map(ncap * Range.sizeof);
             if (p is null) onOutOfMemoryError();
             if (_p !is null)


### PR DESCRIPTION
- collect all live objects in a todo stack
  to be marked later

- remove outer anychanges loop and scan GCBits

- only mark todo items after current mark(p1, p2) is done
  to benefit from cache locality, prefetcher and tail recursion