### PR TITLE
Fix wrong copy-pasta from object_.d.

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -552,7 +552,7 @@ auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc @property
         Result save() { return this; }
     }
 
-    return Result(_aaRange(p));
+    return Result(_aaRange(cast(void*)aa));
 }
 
 inout(V) get(K, V)(inout(V[K]) aa, K key, lazy inout(V) defaultValue)


### PR DESCRIPTION
We seriously need to automate the generation of `object.di`... this is an embarrassment.