### PR TITLE
.save needs to be @property otherwise isForwardRange fails.

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -549,7 +549,7 @@ auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc @property
                         cast(Value*)_aaRangeFrontValue(r));
         }
         void popFront() { _aaRangePopFront(r); }
-        Result save() { return this; }
+        @property Result save() { return this; }
     }
 
     return Result(_aaRange(cast(void*)aa));

--- a/src/object_.d
+++ b/src/object_.d
@@ -2149,7 +2149,7 @@ auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc @property
                         cast(Value*)_aaRangeFrontValue(r));
         }
         void popFront() { _aaRangePopFront(r); }
-        Result save() { return this; }
+        @property Result save() { return this; }
     }
 
     return Result(_aaRange(cast(void*)aa));


### PR DESCRIPTION
Sigh... yet one more thing overlooked in `byKeyValue`.