### PR TITLE
16-Byte Cas, AtomicStore and AtomicLoad added to core.atomic.

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -691,7 +691,7 @@ else version( AsmX86_64 )
     }
 
     bool cas(T,V1,V2)( shared(T)* here, const shared(V1)* ifThis, shared(V2)* writeThis ) nothrow
-        if( is(T U : U*) && __traits( compliles, { *here = writeThis; } ) )
+        if( is(T U : U*) && __traits( compiles, { *here = writeThis; } ) )
     {
         return casImpl(here, ifThis, writeThis);
     }

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1280,7 +1280,7 @@ version( unittest )
                 long value2;
             }
             
-            shared DoubleValue a;
+            align(16) shared DoubleValue a;
             atomicStore(a, DoubleValue(1,2));
             assert(a.value1 == 1 && a.value2 ==2);
             

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1014,7 +1014,7 @@ else version( AsmX86_64 )
                     pop RBX;
                     pop RDI;
                 }
-                return cast(T) retVal;
+                return cast(typeof(return)) retVal;
             }else{
                 asm pure nothrow @nogc
                 {

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1237,6 +1237,25 @@ version( unittest )
             testType!(long)();
             testType!(ulong)();
         }
+        
+        static if (has128BitCAS)
+        {
+            struct DoubleValue
+            {
+                long value1;
+                long value2;
+            }
+            
+            shared DoubleValue a;
+            atomicStore(a, DoubleValue(1,2));
+            assert(a.value1 == 1 && a.value2 ==2);
+            
+            while(!cas(&a, DoubleValue(1,2), DoubleValue(3,4))){}
+            assert(a.value1 == 3 && a.value2 ==4);
+            
+            DoubleValue b = atomicLoad(a);
+            assert(b.value1 == 3 && b.value2 ==4);
+        }
 
         shared(size_t) i;
 


### PR DESCRIPTION
16-Byte operations added for atomicStore, atomicLoad and CAS (module: core.atomic).
(ie. double-word added for 64 bit machines.  It is already available on 32 bit machines.)