### PR TITLE
Add missing imports

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -443,7 +443,9 @@ else version( Posix )
         // avoid deadlocks in signal handler, see Issue 13416
         version (FreeBSD) bool THR_IN_CRITICAL(pthread_t p) nothrow @nogc
         {
-            import core.sys.posix.sys.types : c_long, lwpid_t;
+            import core.sys.posix.config : c_long;
+            import core.sys.posix.sys.types : lwpid_t;
+
             // If the begin of pthread would be changed in libthr (unlikely)
             // we'll run into undefined behavior, compare with thr_private.h.
             static struct pthread


### PR DESCRIPTION
`core.sys.posix.sys.types` privately imports `core.sys.posix.config`, so `c_long` should be invisible via `core.sys.posix.sys.types` module.