### PR TITLE
gc.gc: Fix memory allocation in rootIter

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -1154,19 +1154,20 @@ class GC
     }
 
 
+    private auto rootIterImpl(scope int delegate(ref Root) nothrow dg)
+    {
+        gcLock.lock();
+        auto res = gcx.roots.opApply(dg);
+        gcLock.unlock();
+        return res;
+    }
+
     /**
      *
      */
     @property auto rootIter()
     {
-        auto iter(scope int delegate(ref Root) nothrow dg)
-        {
-            gcLock.lock();
-            auto res = gcx.roots.opApply(dg);
-            gcLock.unlock();
-            return res;
-        }
-        return &iter;
+        return &rootIterImpl;
     }
 
 


### PR DESCRIPTION
Introduced in 426b7a0661aa34161a465dd635c8bf0c0e7a0d70