### PR TITLE
version away __unused1/2/3 for X86_64

### DIFF
--- a/src/core/sys/posix/sys/shm.d
+++ b/src/core/sys/posix/sys/shm.d
@@ -60,16 +60,17 @@ version( linux )
 
     alias c_ulong   shmatt_t;
 
+    /* For any changes, please check /usr/include/bits/shm.h */
     struct shmid_ds
     {
         ipc_perm    shm_perm;
         size_t      shm_segsz;
         time_t      shm_atime;
-        c_ulong     __unused1;
+        version( X86_64 ) {} else c_ulong     __unused1;
         time_t      shm_dtime;
-        c_ulong     __unused2;
+        version( X86_64 ) {} else c_ulong     __unused2;
         time_t      shm_ctime;
-        c_ulong     __unused3;
+        version( X86_64 ) {} else c_ulong     __unused3;
         pid_t       shm_cpid;
         pid_t       shm_lpid;
         shmatt_t    shm_nattch;


### PR DESCRIPTION
Fixes [Issue 14007 - shmctl with IPC_STAT returns wrong number of attachments. shmid_ds is defined wrong.](https://issues.dlang.org/show_bug.cgi?id=14007)

Fix originally by [tcak via Bugzilla](https://issues.dlang.org/show_bug.cgi?id=14007#c4).