### PR TITLE
suspend threads in parallel

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -385,15 +385,10 @@ else version( Posix )
                 // NOTE: Since registers are being pushed and popped from the
                 //       stack, any other stack data used by this function should
                 //       be gone before the stack cleanup code is called below.
-                Thread  obj = Thread.getThis();
+                Thread obj = Thread.getThis();
+                assert(obj !is null);
 
-                // NOTE: The thread reference returned by getThis is set within
-                //       the thread startup code, so it is possible that this
-                //       handler may be called before the reference is set.  In
-                //       this case it is safe to simply suspend and not worry
-                //       about the stack pointers as the thread will not have
-                //       any references to GC-managed data.
-                if( obj && !obj.m_lock )
+                if( !obj.m_lock )
                 {
                     obj.m_curr.tstack = getStackTop();
                 }
@@ -413,7 +408,7 @@ else version( Posix )
 
                 sigsuspend( &sigres );
 
-                if( obj && !obj.m_lock )
+                if( !obj.m_lock )
                 {
                     obj.m_curr.tstack = obj.m_curr.bstack;
                 }

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2577,14 +2577,6 @@ extern (C) void thread_suspendAll() nothrow
         if( ++suspendDepth > 1 )
             return;
 
-        // NOTE: I'd really prefer not to check isRunning within this loop but
-        //       not doing so could be problematic if threads are terminated
-        //       abnormally and a new thread is created with the same thread
-        //       address before the next GC run.  This situation might cause
-        //       the same thread to be suspended twice, which would likely
-        //       cause the second suspend to fail, the garbage collection to
-        //       abort, and Bad Things to occur.
-
         Thread.criticalRegionLock.lock_nothrow();
         auto t = Thread.sm_tbeg;
         while (t)


### PR DESCRIPTION
- heavily reduce suspendAll time with many threads by signalling all N
  threads in parallel and then waiting N times for the semaphore rather
  than doing that serially
- won't improve anything on OSX/Windows which do use a synchronous
  suspend API