### PR TITLE
Add UDA for specifying selector for Objective-C methods.

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -1,6 +1,7 @@
 COPY=\
 	$(IMPDIR)\object.d \
 	$(IMPDIR)\core\atomic.d \
+	$(IMPDIR)\core\attribute.d \
 	$(IMPDIR)\core\bitop.d \
 	$(IMPDIR)\core\checkedint.d \
 	$(IMPDIR)\core\cpuid.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -1,6 +1,7 @@
 DOCS=\
 	$(DOCDIR)\object.html \
 	$(DOCDIR)\core_atomic.html \
+	$(DOCDIR)\core_attribute.html \
 	$(DOCDIR)\core_bitop.html \
 	$(DOCDIR)\core_checkedint.html \
 	$(DOCDIR)\core_cpuid.html \

--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -18,6 +18,7 @@ MANIFEST=\
 	src\test_runner.d \
 	\
 	src\core\atomic.d \
+	src\core\attribute.d \
 	src\core\bitop.d \
 	src\core\checkedint.d \
 	src\core\cpuid.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -2,6 +2,7 @@ SRCS=\
 	src\object.d \
 	\
 	src\core\atomic.d \
+	src\core\attribute.d \
 	src\core\bitop.d \
 	src\core\checkedint.d \
 	src\core\cpuid.d \

--- a/src/core/attribute.d
+++ b/src/core/attribute.d
@@ -1,0 +1,57 @@
+/**
+ * This module contains UDA's (User Defined Attributes) either used in
+ * the runtime or special UDA's recognized by compiler.
+ *
+ * Copyright: Copyright Jacob Carlborg 2015.
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Jacob Carlborg
+ * Source:    $(DRUNTIMESRC core/_attribute.d)
+ */
+
+/*          Copyright Jacob Carlborg 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module core.attribute;
+
+/**
+ * Use this attribute to attach an Objective-C selector to a method.
+ *
+ * This is a special compiler recognized attribute, it has several
+ * requirements, which all will be enforced by the compiler:
+ *
+ * $(UL
+ *  $(LI
+ *      The attribute can only be attached to methods or constructors which
+ *      have Objective-C linkage. That is, a method or a constructor in a
+ *      class or interface declared as $(D_CODE extern(Objective-C)).
+ *  ),
+ *
+ *  $(LI It cannot be attached to a method or constructor that is a template),
+ *
+ *  $(LI
+ *      The number of colons in the string need to match the number of
+ *      arguments the method accept.
+ *  ),
+ *
+ *  $(LI It can only be used once in a method declaration)
+ * )
+ *
+ * Examples:
+ * ---
+ * extern (Objective-C)
+ * class NSObject
+ * {
+ *  this() @selector("init");
+ *  static NSObject alloc() @selector("alloc");
+ *  NSObject initWithUTF8String(in char* str) @selector("initWithUTF8String:");
+ *  ObjcObject copyScriptingValue(ObjcObject value, NSString key, NSDictionary properties)
+ *      @selector("copyScriptingValue:forKey:withProperties:");
+ * }
+ * ---
+ */
+version (D_ObjectiveC) struct selector
+{
+    string selector;
+}

--- a/src/object.d
+++ b/src/object.d
@@ -49,6 +49,8 @@ alias immutable(char)[]  string;
 alias immutable(wchar)[] wstring;
 alias immutable(dchar)[] dstring;
 
+version (D_ObjectiveC) public import core.attribute : selector;
+
 /**
  * All D class objects inherit from Object.
  */

--- a/win32.mak
+++ b/win32.mak
@@ -47,6 +47,9 @@ $(DOCDIR)\object.html : src\object.d
 $(DOCDIR)\core_atomic.html : src\core\atomic.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
+$(DOCDIR)\core_attribute.html : src\core\attribute.d
+	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
+
 $(DOCDIR)\core_bitop.html : src\core\bitop.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
@@ -212,6 +215,9 @@ $(IMPDIR)\object.d : src\object.d
 	if exist $(IMPDIR)\object.di del $(IMPDIR)\object.di
 
 $(IMPDIR)\core\atomic.d : src\core\atomic.d
+	copy $** $@
+
+$(IMPDIR)\core\attribute.d : src\core\attribute.d
 	copy $** $@
 
 $(IMPDIR)\core\bitop.d : src\core\bitop.d

--- a/win64.mak
+++ b/win64.mak
@@ -56,6 +56,9 @@ $(DOCDIR)\object.html : src\object.d
 $(DOCDIR)\core_atomic.html : src\core\atomic.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
+$(DOCDIR)\core_attribute.html : src\core\attribute.d
+	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
+
 $(DOCDIR)\core_bitop.html : src\core\bitop.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
@@ -222,6 +225,9 @@ $(IMPDIR)\object.d : src\object.d
 	if exist $(IMPDIR)\object.di del $(IMPDIR)\object.di
 
 $(IMPDIR)\core\atomic.d : src\core\atomic.d
+	copy $** $@
+
+$(IMPDIR)\core\attribute.d : src\core\attribute.d
 	copy $** $@
 
 $(IMPDIR)\core\bitop.d : src\core\bitop.d


### PR DESCRIPTION
The runtime part of https://github.com/D-Programming-Language/dmd/pull/4321. This could be pulled before the DMD pull request and should not affect anything.