### PR TITLE
don't suspend starting threads

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -684,16 +684,6 @@ class Thread
                     throw new ThreadException( "Error creating thread" );
             }
 
-            // NOTE: when creating threads from inside a DLL, DllMain(THREAD_ATTACH)
-            //       might be called before ResumeThread returns, but the dll
-            //       helper functions need to know whether the thread is created
-            //       from the runtime itself or from another DLL or the application
-            //       to just attach to it
-            //       as a consequence, the new Thread object is added before actual
-            //       creation of the thread. There should be no problem with the GC
-            //       calling thread_suspendAll, because of the slock synchronization
-            //
-            // VERIFY: does this actually also apply to other platforms?
             add( this );
             return this;
         }

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -401,7 +401,7 @@ else version( Posix )
                 status = sigdelset( &sigres, resumeSignalNumber );
                 assert( status == 0 );
 
-                version (FreeBSD) Thread.sm_suspendagain = false;
+                version (FreeBSD) obj.m_suspendagain = false;
                 status = sem_post( &suspendCount );
                 assert( status == 0 );
 
@@ -418,7 +418,7 @@ else version( Posix )
             {
                 if (THR_IN_CRITICAL(pthread_self()))
                 {
-                    Thread.sm_suspendagain = true;
+                    Thread.getThis().m_suspendagain = true;
                     if (sem_post(&suspendCount)) assert(0);
                     return;
                 }
@@ -1337,7 +1337,7 @@ private:
     version (FreeBSD)
     {
         // set when suspend failed and should be retried, see Issue 13416
-        static shared bool sm_suspendagain;
+        shared bool m_suspendagain;
     }
 
 
@@ -2448,7 +2448,7 @@ private void suspend( Thread t ) nothrow
             version (FreeBSD)
             {
                 // avoid deadlocks, see Issue 13416
-                if (Thread.sm_suspendagain) goto Lagain;
+                if (t.m_suspendagain) goto Lagain;
             }
         }
         else if( !t.m_lock )


### PR DESCRIPTION
- avoids extra complications in signal handler
  because the TLS thread reference is set when
  suspension can occur

- required for parallel suspend #1110