### PR TITLE
use fixed seeds for rand_{small,large} benchmark

### DIFF
--- a/benchmark/gcbench/rand_large.d
+++ b/benchmark/gcbench/rand_large.d
@@ -15,14 +15,23 @@ import std.random, core.memory, std.stdio;
 
 enum nIter = 1000;
 
-void main() {
+void main()
+{
+    version (RANDOMIZE)
+        auto rnd = Random(unpredictableSeed);
+    else
+        auto rnd = Random(1202387523);
+
     auto ptrs = new void*[1024];
 
     // Allocate 1024 large blocks with size uniformly distributed between 1
     // and 128 kilobytes.
-    foreach(i; 0..nIter) {
-        foreach(ref ptr; ptrs) {
-            ptr = GC.malloc(uniform(1024, 128 * 1024 + 1), GC.BlkAttr.NO_SCAN);
+    foreach(i; 0..nIter)
+    {
+        foreach(ref ptr; ptrs)
+        {
+            immutable sz = uniform(1024, 128 * 1024 + 1, rnd);
+            ptr = GC.malloc(sz, GC.BlkAttr.NO_SCAN);
         }
     }
 }

--- a/benchmark/gcbench/rand_small.d
+++ b/benchmark/gcbench/rand_small.d
@@ -19,13 +19,21 @@ void main(string[] args)
     if(args.length > 1)
         nIter = to!size_t(args[1]);
 
+    version (RANDOMIZE)
+        auto rnd = Random(unpredictableSeed);
+    else
+        auto rnd = Random(2929088778);
+
     auto ptrs = new void*[4096];
 
     // Allocate large blocks with size uniformly distributed between 8
     // and 2048 bytes.
-    foreach(i; 0..nIter) {
-        foreach(ref ptr; ptrs) {
-            ptr = GC.malloc(uniform(8, 2048), GC.BlkAttr.NO_SCAN);
+    foreach(i; 0..nIter)
+    {
+        foreach(ref ptr; ptrs)
+        {
+            immutable sz = uniform(8, 2048, rnd);
+            ptr = GC.malloc(sz, GC.BlkAttr.NO_SCAN);
         }
     }
 }


### PR DESCRIPTION
- seeds were produced by running unpredictableSeed