### PR TITLE
Required fix for issue 9495

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -96,10 +96,7 @@ else version (Windows) // Win64
      * Initialize ap.
      * parmn should be the last named parameter.
      */
-    void va_start(T)(out va_list ap, ref T parmn)
-    {
-        ap = cast(va_list)(cast(void*)&parmn + ((size_t.sizeof + size_t.sizeof - 1) & ~(size_t.sizeof - 1)));
-    }
+    void va_start(T)(out va_list ap, ref T parmn); // Compiler intrinsic
 
     /************
      * Retrieve and return the next value that is type T.


### PR DESCRIPTION
Remove va_start's body, as it is not an intrinsic function.  The old body was incorrect, and leaving it intact results in wrong-code when it is inlined.

https://github.com/D-Programming-Language/dmd/pull/4336