### PR TITLE
Remove va_start's body on posix64 so it doesn't get inlined

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -190,10 +190,7 @@ else version (X86_64)
     alias va_list = __va_list*;
 
     ///
-    void va_start(T)(out va_list ap, ref T parmn)
-    {
-        ap = &parmn.va;
-    }
+    void va_start(T)(out va_list ap, ref T parmn); // Compiler intrinsic
 
     ///
     T va_arg(T)(va_list ap)


### PR DESCRIPTION
Needs to be merged at the same time as https://github.com/D-Programming-Language/dmd/pull/4343