### PR TITLE
fix RangeError in _aaKeys

### DIFF
--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -480,7 +480,7 @@ inout(ArrayRet_t) _aaKeys(inout AA aa, in size_t keysize, const TypeInfo tiKeyAr
     if (!len)
         return null;
 
-    void[] res = _d_newarrayU(tiKeyArray, len);
+    void* res = _d_newarrayU(tiKeyArray, len).ptr;
 
     size_t resi = 0;
     // note, can't use firstUsedBucketCache here, aa is inout
@@ -498,7 +498,7 @@ inout(ArrayRet_t) _aaKeys(inout AA aa, in size_t keysize, const TypeInfo tiKeyAr
 
     Array a;
     a.length = len;
-    a.ptr = res.ptr;
+    a.ptr = res;
     return *cast(inout ArrayRet_t*)(&a);
 }
 


### PR DESCRIPTION
_d_newarrayU returns an array of `void[]`, but the length is set with respect to the actual type T of `new T[n]`. That's why a normal indexing causes a range error when building a debug version of druntime.

I think returning `void*` would be better, but the result is forwarded by `_d_newarrayT`, `_d_newarrayiT` and `_rawDup!T`. I didn't want to open that can of worms.