### PR TITLE
Fix posix resource.d header for ARM

### DIFF
--- a/src/core/sys/posix/sys/resource.d
+++ b/src/core/sys/posix/sys/resource.d
@@ -361,6 +361,27 @@ else
     int setpriority(int, id_t, int);
 }
 
-int getrlimit(int, rlimit*);
-int getrusage(int, rusage*);
-int setrlimit(int, in rlimit*);
+version (linux)
+{
+    static if (__USE_FILE_OFFSET64)
+    {
+        int getrlimit64(int, rlimit*);
+        int getrusage64(int, rusage*);
+        int setrlimit64(int, in rlimit*);
+        alias getrlimit = getrlimit64;
+        alias getrusage = getrusage64;
+        alias setrlimit = setrlimit64;
+    }
+    else
+    {
+        int getrlimit(int, rlimit*);
+        int getrusage(int, rusage*);
+        int setrlimit(int, in rlimit*);
+    }
+}
+else
+{
+    int getrlimit(int, rlimit*);
+    int getrusage(int, rusage*);
+    int setrlimit(int, in rlimit*);
+}


### PR DESCRIPTION
If `__USE_FILE_OFFSET64` is specified we need to use the `*64` functions.