### PR TITLE
mman: fix AAarch64 version check

### DIFF
--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -216,7 +216,7 @@ else version (X86_64)
     }
 }
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/unix/sysv/linux/aarch64/bits/mman.h
-else version (AARCH64)
+else version (AArch64)
 {
     static if (__USE_MISC) enum
     {


### PR DESCRIPTION
---
Noticed this when working on Android stuff; untested, but everything else spells it `AArch64`.