### PR TITLE
allow GC API profiling with --DRT-gcopt=profile:2

### DIFF
--- a/src/gc/config.d
+++ b/src/gc/config.d
@@ -23,7 +23,7 @@ extern extern(C) __gshared string[] rt_options;
 struct Config
 {
     bool disable;            // start disabled
-    bool profile;            // enable profiling with summary when terminating program
+    byte profile;            // enable profiling with summary when terminating program
     bool precise;            // enable precise scanning
     bool concurrent;         // enable concurrent collection
 

--- a/src/gc/config.d
+++ b/src/gc/config.d
@@ -23,7 +23,7 @@ extern extern(C) __gshared string[] rt_options;
 struct Config
 {
     bool disable;            // start disabled
-    byte profile;            // enable profiling with summary when terminating program
+    ubyte profile;           // enable profiling with summary when terminating program
     bool precise;            // enable precise scanning
     bool concurrent;         // enable concurrent collection
 
@@ -60,7 +60,7 @@ struct Config
 
         string s = "GC options are specified as white space separated assignments:
     disable:0|1    - start disabled (%d)
-    profile:0|1    - enable profiling with summary when terminating program (%d)
+    profile:0|1|2  - enable profiling with summary when terminating program (%d)
     precise:0|1    - enable precise scanning (not implemented yet)
     concurrent:0|1 - enable concurrent collection (not implemented yet)
 
@@ -207,28 +207,33 @@ unittest
     scope (exit) inUnittest = false;
 
     Config conf;
-    assert(!conf.parseOptions("profile"));
-    assert(!conf.parseOptions("profile:"));
-    assert(!conf.parseOptions("profile:5"));
-    assert(conf.parseOptions("profile:y") && conf.profile);
-    assert(conf.parseOptions("profile:n") && !conf.profile);
-    assert(conf.parseOptions("profile:Y") && conf.profile);
-    assert(conf.parseOptions("profile:N") && !conf.profile);
-    assert(conf.parseOptions("profile:1") && conf.profile);
-    assert(conf.parseOptions("profile:0") && !conf.profile);
+    assert(!conf.parseOptions("disable"));
+    assert(!conf.parseOptions("disable:"));
+    assert(!conf.parseOptions("disable:5"));
+    assert(conf.parseOptions("disable:y") && conf.disable);
+    assert(conf.parseOptions("disable:n") && !conf.disable);
+    assert(conf.parseOptions("disable:Y") && conf.disable);
+    assert(conf.parseOptions("disable:N") && !conf.disable);
+    assert(conf.parseOptions("disable:1") && conf.disable);
+    assert(conf.parseOptions("disable:0") && !conf.disable);
 
-    assert(conf.parseOptions("profile=y") && conf.profile);
-    assert(conf.parseOptions("profile=n") && !conf.profile);
+    assert(conf.parseOptions("disable=y") && conf.disable);
+    assert(conf.parseOptions("disable=n") && !conf.disable);
 
-    assert(conf.parseOptions("profile:1 minPoolSize:16"));
-    assert(conf.profile);
+    assert(conf.parseOptions("profile=0") && conf.profile == 0);
+    assert(conf.parseOptions("profile=1") && conf.profile == 1);
+    assert(conf.parseOptions("profile=2") && conf.profile == 2);
+    assert(!conf.parseOptions("profile=256"));
+
+    assert(conf.parseOptions("disable:1 minPoolSize:16"));
+    assert(conf.disable);
     assert(conf.minPoolSize == 16);
 
     assert(conf.parseOptions("heapSizeFactor:3.1"));
     assert(conf.heapSizeFactor == 3.1f);
-    assert(conf.parseOptions("heapSizeFactor:3.1234567890 profile:0"));
+    assert(conf.parseOptions("heapSizeFactor:3.1234567890 disable:0"));
     assert(conf.heapSizeFactor > 3.123f);
-    assert(!conf.profile);
+    assert(!conf.disable);
     assert(!conf.parseOptions("heapSizeFactor:3.0.2.5"));
     assert(conf.parseOptions("heapSizeFactor:2"));
     assert(conf.heapSizeFactor == 2.0f);

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -59,61 +59,7 @@ else                   import core.stdc.stdio : sprintf, printf; // needed to ou
 
 import core.time;
 alias currTime = MonoTime.currTime;
-
-// high performance time measurements without additional translations
-alias MonoTimeNative = long;
-alias DurationNative = long;
-
-version(OSX) extern(C) ulong mach_absolute_time() nothrow @nogc;
-
-@property MonoTimeNative currTimeNative() nothrow
-{
-    version(Windows)
-    {
-        import core.sys.windows.windows;
-        long ticks;
-        if(QueryPerformanceCounter(&ticks) == 0)
-        {
-            // This probably cannot happen on Windows 95 or later
-            assert(0, "Call to QueryPerformanceCounter failed.");
-        }
-        return ticks;
-    }
-    else version(OSX)
-    {
-        return mach_absolute_time();
-    }
-    else version(Posix)
-    {
-        import core.sys.posix.time;
-        import core.sys.posix.sys.time;
-
-        timespec ts;
-        if(clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
-            assert(0, "Call to clock_gettime failed.");
-
-        return ts.tv_sec * 1_000_000_000L + ts.tv_nsec;
-    }
-    else
-        static assert(false, "no native timer function");
-}
-
-MonoTime toMonoTime(MonoTimeNative tm)
-{
-    version(Windows)
-        return MonoTime(tm);
-    else version(OSX)
-        return MonoTime(tm);
-    else version(Posix)
-        return MonoTime(convClockFreq(tm, 1_000_000_000L, MonoTime.ticksPerSecond));
-    else
-        static assert(false, "no native timer function");
-}
-
-Duration toDuration(DurationNative dur)
-{
-    return toMonoTime(dur) - MonoTime(0);
-}
+long currTicks() { return MonoTime.ticksPerSecond ? MonoTime.currTime.ticks : 0; }
 
 debug(PRINTF_TO_FILE)
 {
@@ -171,12 +117,12 @@ __gshared long numFrees;
 __gshared long numReallocs;
 __gshared long numExtends;
 __gshared long numOthers;
-__gshared DurationNative mallocTime;
-__gshared DurationNative freeTime;
-__gshared DurationNative reallocTime;
-__gshared DurationNative extendTime;
-__gshared DurationNative otherTime;
-__gshared DurationNative lockTime;
+__gshared long mallocTime; // using ticks instead of MonoTime for better performance
+__gshared long freeTime;
+__gshared long reallocTime;
+__gshared long extendTime;
+__gshared long otherTime;
+__gshared long lockTime;
 
 private
 {
@@ -403,14 +349,14 @@ struct GC
     {
         debug(PROFILE_API)
         {
-            MonoTimeNative tm = (GC.config.profile > 1 ? currTimeNative : 0);
+            long tm = (GC.config.profile > 1 ? currTicks : 0);
         }
 
         bool locked = (gcLock.lock(), true);
 
         debug(PROFILE_API)
         {
-            MonoTimeNative tm2 = (GC.config.profile > 1 ? currTimeNative : 0);
+            long tm2 = (GC.config.profile > 1 ? currTicks : 0);
         }
     }
 
@@ -422,7 +368,7 @@ struct GC
                 if (GC.config.profile > 1)
                 {
                     count++;
-                    MonoTimeNative now = currTimeNative;
+                    long now = currTicks;
                     lockTime += tm2 - tm;
                     time += now - tm2;
                 }
@@ -1529,17 +1475,22 @@ struct Gcx
             apitxt[0] = 0;
             debug(PROFILE_API) if (GC.config.profile > 1)
             {
-                printf("\n");
-                printf("\tmalloc:  %llu calls, %lld ms\n", cast(ulong)numMallocs, mallocTime.toDuration.total!"msecs");
-                printf("\trealloc: %llu calls, %lld ms\n", cast(ulong)numReallocs, reallocTime.toDuration.total!"msecs");
-                printf("\tfree:    %llu calls, %lld ms\n", cast(ulong)numFrees, freeTime.toDuration.total!"msecs");
-                printf("\textend:  %llu calls, %lld ms\n", cast(ulong)numExtends, extendTime.toDuration.total!"msecs");
-                printf("\tother:   %llu calls, %lld ms\n", cast(ulong)numOthers, otherTime.toDuration.total!"msecs");
-                printf("\tlock time: %lld ms\n", lockTime.toDuration.total!"msecs");
+                static Duration toDuration(long dur)
+                {
+                    return MonoTime(dur) - MonoTime(0);
+                }
 
-                DurationNative apiTime = mallocTime + reallocTime + freeTime + extendTime + otherTime + lockTime;
-                printf("\tGC API: %lld ms\n", apiTime.toDuration.total!"msecs");
-                sprintf(apitxt.ptr, " API%5ld ms", apiTime.toDuration.total!"msecs");
+                printf("\n");
+                printf("\tmalloc:  %llu calls, %lld ms\n", cast(ulong)numMallocs, toDuration(mallocTime).total!"msecs");
+                printf("\trealloc: %llu calls, %lld ms\n", cast(ulong)numReallocs, toDuration(reallocTime).total!"msecs");
+                printf("\tfree:    %llu calls, %lld ms\n", cast(ulong)numFrees, toDuration(freeTime).total!"msecs");
+                printf("\textend:  %llu calls, %lld ms\n", cast(ulong)numExtends, toDuration(extendTime).total!"msecs");
+                printf("\tother:   %llu calls, %lld ms\n", cast(ulong)numOthers, toDuration(otherTime).total!"msecs");
+                printf("\tlock time: %lld ms\n", toDuration(lockTime).total!"msecs");
+
+                long apiTime = mallocTime + reallocTime + freeTime + extendTime + otherTime + lockTime;
+                printf("\tGC API: %lld ms\n", toDuration(apiTime).total!"msecs");
+                sprintf(apitxt.ptr, " API%5ld ms", toDuration(apiTime).total!"msecs");
             }
 
             printf("GC summary:%5lld MB,%5lld GC%5lld ms, Pauses%5lld ms <%5lld ms%s\n",


### PR DESCRIPTION
Here's a benchmark result with API time:
```
R bulk             1.075 s,    38 MB,   16 GC  173 ms, Pauses   79 ms <   15 ms API  616 ms
R resize           0.872 s,    12 MB,   11 GC   24 ms, Pauses    2 ms <    0 ms API  133 ms
R string           0.027 s,     5 MB,    2 GC    0 ms, Pauses    0 ms <    0 ms API    1 ms
R conalloc         0.069 s,     5 MB,   83 GC   10 ms, Pauses   10 ms <    0 ms API   12 ms
R conappend        0.014 s,     5 MB,    6 GC    0 ms, Pauses    0 ms <    0 ms API    4 ms
R concpu           0.092 s,     5 MB,   79 GC   34 ms, Pauses   33 ms <    0 ms API   34 ms
R conmsg           0.805 s,     5 MB,  130 GC   44 ms, Pauses   15 ms <    0 ms API  552 ms
R dlist            1.834 s,    12 MB,   52 GC  331 ms, Pauses  227 ms <    4 ms API  692 ms
R huge_single      0.011 s,  1501 MB,    3 GC    0 ms, Pauses    0 ms <    0 ms API    0 ms
R rand_large       3.164 s,    92 MB, 3152 GC  304 ms, Pauses  194 ms <    0 ms API 3118 ms
R rand_small       0.768 s,    12 MB, 2032 GC  368 ms, Pauses  209 ms <    0 ms API  594 ms
R slist            1.749 s,    12 MB,   52 GC  285 ms, Pauses  180 ms <    3 ms API  648 ms
R testgc3          1.312 s,    70 MB,   11 GC  357 ms, Pauses  247 ms <   57 ms API  878 ms
R tree1            0.930 s,    12 MB,   98 GC  442 ms, Pauses  333 ms <    6 ms API  692 ms
R tree2            1.078 s,     1 MB,  216 GC   73 ms, Pauses    9 ms <    0 ms API  333 ms
R words            0.913 s,   292 MB,    9 GC  145 ms, Pauses  144 ms <   77 ms API   68 ms
```

Example output details for dlist:
```
	malloc:  9768628 calls, 531 ms
 	realloc: 0 calls, 0 ms
 	free:    0 calls, 0 ms
 	extend:  1100 calls, 0 ms
 	other:   826 calls, 0 ms
 	lock time: 160 ms
 	GC API: 692 ms
GC summary:   12 MB,   52 GC  331 ms, Pauses  227 ms <    4 ms API  692 ms
```
malloc includes collections, GC.lock time not included in single function time.

Running it disabled has a tiny impact on performance, so I've made it optional with -debug=PROFILE_API.

This also corrects a copy and paste error in runbench which fails to extract the GC summary from gcx.log.
