### PR TITLE
fix Issue 14104 - aa with pointer key type doesn't find existing value

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -358,6 +358,7 @@ class TypeInfo_Enum : TypeInfo_Typedef
 
 }
 
+// Please make sure to keep this in sync with TypeInfo_P (src/rt/typeinfo/ti_ptr.d)
 class TypeInfo_Pointer : TypeInfo
 {
     override string toString() const { return m_next.toString() ~ "*"; }

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -987,3 +987,14 @@ void _aaRangePopFront(ref Range r) pure nothrow @nogc
         }
     }
 }
+
+// Bugzilla 14104
+unittest
+{
+    import core.stdc.stdio;
+    alias K = const(ubyte)*;
+    size_t[K] aa;
+    immutable key = cast(K)(cast(size_t)uint.max + 1);
+    aa[key] = 12;
+    assert(key in aa);
+}

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -82,7 +82,7 @@ struct Impl
     size_t firstUsedBucketCache() @safe pure nothrow @nogc
     in
     {
-        assert(firstUsedBucket < buckets.length);
+        assert(firstUsedBucket <= buckets.length);
         foreach(i; 0 .. firstUsedBucket)
             assert(buckets[i] is null);
     }

--- a/src/rt/typeinfo/ti_ptr.d
+++ b/src/rt/typeinfo/ti_ptr.d
@@ -13,7 +13,8 @@
  */
 module rt.typeinfo.ti_ptr;
 
-// pointer
+// internal typeinfo for any pointer type
+// please keep in sync with TypeInfo_Pointer
 
 class TypeInfo_P : TypeInfo
 {
@@ -24,22 +25,22 @@ class TypeInfo_P : TypeInfo
 
     override size_t getHash(in void* p)
     {
-        return cast(uint)*cast(void* *)p;
+        return cast(size_t)*cast(void**)p;
     }
 
     override bool equals(in void* p1, in void* p2)
     {
-        return *cast(void* *)p1 == *cast(void* *)p2;
+        return *cast(void**)p1 == *cast(void**)p2;
     }
 
     override int compare(in void* p1, in void* p2)
     {
-        auto c = *cast(void* *)p1 - *cast(void* *)p2;
-        if (c < 0)
+        if (*cast(void**)p1 < *cast(void**)p2)
             return -1;
-        else if (c > 0)
+        else if (*cast(void**)p1 > *cast(void**)p2)
             return 1;
-        return 0;
+        else
+            return 0;
     }
 
     override @property size_t tsize() nothrow pure
@@ -49,15 +50,10 @@ class TypeInfo_P : TypeInfo
 
     override void swap(void *p1, void *p2)
     {
-        void* t;
-
-        t = *cast(void* *)p1;
-        *cast(void* *)p1 = *cast(void* *)p2;
-        *cast(void* *)p2 = t;
+        void* tmp = *cast(void**)p1;
+        *cast(void**)p1 = *cast(void**)p2;
+        *cast(void**)p2 = tmp;
     }
 
-    override @property uint flags() nothrow pure
-    {
-        return 1;
-    }
+    override @property uint flags() nothrow pure const { return 1; }
 }


### PR DESCRIPTION
- the internal TypeInfo_P.getHash for pointers trucated the hash to
  32-bit unlike the TypeInfo_Pointer.getHash
- internal TypeInfos are used when no full type information is needed
  so they must behave identical

[Issue 14104 – aa with pointer key type doesn't find existing value](https://issues.dlang.org/show_bug.cgi?id=14104)