### PR TITLE
spinlock for GC

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -16,6 +16,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\internal\convert.d \
 	$(IMPDIR)\core\internal\hash.d \
+	$(IMPDIR)\core\internal\spinlock.d \
 	$(IMPDIR)\core\internal\traits.d \
 	\
 	$(IMPDIR)\core\stdc\complex.d \

--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -34,6 +34,7 @@ MANIFEST=\
 	\
 	src\core\internal\convert.d \
 	src\core\internal\hash.d \
+	src\core\internal\spinlock.d \
 	src\core\internal\traits.d \
 	\
 	src\core\stdc\complex.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -17,6 +17,7 @@ SRCS=\
 	\
 	src\core\internal\convert.d \
 	src\core\internal\hash.d \
+	src\core\internal\spinlock.d \
 	src\core\internal\traits.d \
 	\
 	src\core\stdc\config.d \

--- a/src/core/internal/spinlock.d
+++ b/src/core/internal/spinlock.d
@@ -1,0 +1,86 @@
+/**
+ * SpinLock for runtime internal usage.
+ *
+ * Copyright: Copyright Digital Mars 2015 -.
+ * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Martin Nowak
+ * Source: $(DRUNTIMESRC core/internal/_spinlock.d)
+ */
+module core.internal.spinlock;
+
+import core.atomic, core.thread;
+
+shared struct SpinLock
+{
+    /// for how long is the lock contended
+    enum Contention : ubyte
+    {
+        brief,
+        medium,
+        lengthy,
+    }
+
+@trusted nothrow:
+    this(Contention cont)
+    {
+        this.cont = cont;
+    }
+
+    void lock()
+    {
+        // TTAS lock
+        while (true)
+        {
+            for (size_t n; atomicLoad!(MemoryOrder.raw)(val); ++n)
+                yield(n);
+            if (cas(&val, false, true))
+                return;
+        }
+    }
+
+    void unlock()
+    {
+        atomicStore!(MemoryOrder.rel)(val, false);
+    }
+
+    /// yield with backoff
+    void yield(size_t k)
+    {
+        if (k < pauseThresh >> cont) return pause();
+        else if (k < 32 >> cont) return Thread.yield();
+        Thread.sleep(1.msecs);
+    }
+
+private:
+    version (D_InlineAsm_X86)
+        enum X86 = true;
+    else version (D_InlineAsm_X86_64)
+        enum X86 = true;
+    else
+        enum X86 = false;
+
+    static if (X86)
+    {
+        enum pauseThresh = 16;
+        void pause() { asm @trusted nothrow { rep; nop; } }
+    }
+    else
+    {
+        enum pauseThresh = 4;
+        void pause() {}
+    }
+
+    bool val;
+    Contention cont;
+}
+
+// aligned to cacheline to avoid false sharing
+shared align(64) struct AlignedSpinLock
+{
+    this(SpinLock.Contention cont)
+    {
+        impl = shared(SpinLock)(cont);
+    }
+    SpinLock impl;
+    alias impl this;
+}

--- a/win32.mak
+++ b/win32.mak
@@ -195,6 +195,9 @@ $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\spinlock.d : src\core\internal\spinlock.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\traits.d : src\core\internal\traits.d
 	copy $** $@
 

--- a/win64.mak
+++ b/win64.mak
@@ -202,6 +202,9 @@ $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\spinlock.d : src\core\internal\spinlock.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\traits.d : src\core\internal\traits.d
 	copy $** $@
 


### PR DESCRIPTION
- less overhead than pthread_mutex
- uses test and test-and-set algorithm with configurable backoff