### PR TITLE
Make fstat @trusted

### DIFF
--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -956,7 +956,7 @@ version( linux )
 {
   static if( __USE_LARGEFILE64 )
   {
-    int   fstat64(int, stat_t*);
+    int   fstat64(int, stat_t*) @trusted;
     alias fstat64 fstat;
 
     int   lstat64(in char*, stat_t*);
@@ -967,7 +967,7 @@ version( linux )
   }
   else
   {
-    int   fstat(int, stat_t*);
+    int   fstat(int, stat_t*) @trusted;
     int   lstat(in char*, stat_t*);
     int   stat(in char*, stat_t*);
   }
@@ -976,7 +976,7 @@ else version (Solaris)
 {
     version (D_LP64)
     {
-        int fstat(int, stat_t*);
+        int fstat(int, stat_t*) @trusted;
         int lstat(in char*, stat_t*);
         int stat(in char*, stat_t*);
 
@@ -991,7 +991,7 @@ else version (Solaris)
     {
         static if (__USE_LARGEFILE64)
         {
-            int   fstat64(int, stat_t*);
+            int   fstat64(int, stat_t*) @trusted;
             alias fstat64 fstat;
 
             int   lstat64(in char*, stat_t*);
@@ -1002,7 +1002,7 @@ else version (Solaris)
         }
         else
         {
-            int fstat(int, stat_t*);
+            int fstat(int, stat_t*) @trusted;
             int lstat(in char*, stat_t*);
             int stat(in char*, stat_t*);
         }
@@ -1010,7 +1010,7 @@ else version (Solaris)
 }
 else version( Posix )
 {
-    int   fstat(int, stat_t*);
+    int   fstat(int, stat_t*) @trusted;
     int   lstat(in char*, stat_t*);
     int   stat(in char*, stat_t*);
 }

--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -74,7 +74,7 @@ version(linux) {
         int statvfs64 (const char * file, statvfs_t* buf);
         alias statvfs64 statvfs;
 
-        int fstatvfs64 (int fildes, statvfs_t *buf);
+        int fstatvfs64 (int fildes, statvfs_t *buf) @trusted;
         alias fstatvfs64 fstatvfs;
     }
     else
@@ -108,5 +108,5 @@ else
     }
 
     int statvfs (const char * file, statvfs_t* buf);
-    int fstatvfs (int fildes, statvfs_t *buf);
+    int fstatvfs (int fildes, statvfs_t *buf) @trusted;
 }

--- a/src/core/sys/windows/stat.d
+++ b/src/core/sys/windows/stat.d
@@ -46,5 +46,5 @@ struct struct_stat
 }
 
 int  stat(char *, struct_stat *);
-int  fstat(int, struct_stat *);
+int  fstat(int, struct_stat *) @trusted;
 int  _wstat(wchar *, struct_stat *);


### PR DESCRIPTION
fstat is trusted - it does not escape the pointer passed to it and never does unsafe stuff even if passed a wrong handle