### PR TITLE
Partial fix for Issue 14131 - va_copy is broken on posix X86_64

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -459,10 +459,19 @@ else version (X86_64)
     {
     }
 
+    import core.stdc.stdlib : alloca;
+
     ///
-    void va_copy(out va_list dest, va_list src)
+    void va_copy(out va_list dest, va_list src, void* storage = alloca(__va_list_tag.sizeof))
     {
-        dest = src;
+        // Instead of copying the pointers, and aliasing the source va_list,
+        // the default argument alloca will allocate storage in the caller's
+        // stack frame.  This is still not correct (it should be allocated in
+        // the place where the va_list variable is declared) but most of the
+        // time the caller's stack frame _is_ the place where the va_list is
+        // allocated, so in most cases this will now work.
+        dest = cast(va_list)storage;
+        *dest = *src;
     }
 }
 else


### PR DESCRIPTION
@ibuclaw @andralex 

This doesn't fix the underlying problem, but by allocating new storage with alloca it allows most cases to work, which is a lot better that the current situation.

https://issues.dlang.org/show_bug.cgi?id=14131