### PR TITLE
fix core.time unittests for odd ticksPerSec

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -791,9 +791,9 @@ public:
                     foreach(T; _TypeTuple!(TickDuration, const TickDuration, immutable TickDuration))
                     {
                         auto t = TickDuration.from!units(1);
-                        assert(cast(T)cast(D)dur!units(1) == t, units);
+                        assertApprox(cast(T)cast(D)dur!units(1), t - TickDuration(1), t + TickDuration(1), units);
                         t = TickDuration.from!units(2);
-                        assert(cast(T)cast(D)dur!units(2) == t, units);
+                        assertApprox(cast(T)cast(D)dur!units(2), t - TickDuration(1), t + TickDuration(1), units);
                     }
                 }
                 else


### PR DESCRIPTION
The druntime unittests fail for my desktop system that returns a tick counter frequency of 3906245 Hz. The tests involve floating point operations, so they should allow for some inaccuracy and rounding errors. 
An alternative could be to use normal rounding in the conversoin functions, but that would be a larger change with possible side-effects.