### PR TITLE
runbench: fix omission when changing GC profiling summary text

### DIFF
--- a/benchmark/runbench.d
+++ b/benchmark/runbench.d
@@ -109,7 +109,7 @@ void runTests(Config cfg)
                 auto tgt = bin.setExtension("gcx.log");
                 rename("gcx.log", tgt);
                 auto lines = File(tgt, "r").byLine()
-                    .find!(ln => ln.canFind("maxPoolMemory"));
+                    .find!(ln => ln.canFind("GC summary:"));
                 if (!lines.empty) gcprof = lines.front.find("GC summary:")[11..$].idup;
             }
             else


### PR DESCRIPTION
this brings back the short GC profiling summary when redirecting GC ouptut to gcx.log