### PR TITLE
move MAP_ANON back to core.sys.posix.sys.mman

### DIFF
--- a/src/core/sys/freebsd/sys/mman.d
+++ b/src/core/sys/freebsd/sys/mman.d
@@ -43,11 +43,9 @@ static if (__BSD_VISIBLE)
     enum MAP_NOSYNC = 0x0800;
 
     enum MAP_FILE = 0x0000;
-}
-    // cannot be within __BSD_VISIBLE because of forward reference (Bugzilla 11301)
-    enum MAP_ANON = 0x1000;
-static if (__BSD_VISIBLE)
-{
+
+    // already in core.sys.posix.sys.mman
+    // enum MAP_ANON = 0x1000;
     //#ifndef _KERNEL
     alias MAP_ANONYMOUS = MAP_ANON;
     //#endif /* !_KERNEL */

--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -253,8 +253,9 @@ else version (Alpha)
     static if (__USE_MISC) enum
     {
         MAP_FILE = 0,
-        MAP_ANONYMOUS = 0x10,
-        MAP_ANON = MAP_ANONYMOUS,
+        MAP_ANONYMOUS = MAP_ANON,
+        // in core.sys.posix.sys.mman
+        // MAP_ANON = MAP_ANONYMOUS,
         MAP_HUGE_SHIFT = 26,
         MAP_HUGE_MASK = 0x3f,
     }
@@ -360,8 +361,9 @@ else version (HPPA)
     static if (__USE_MISC) enum
     {
         MAP_FILE = 0,
-        MAP_ANONYMOUS = 0x10,
-        MAP_ANON = MAP_ANONYMOUS,
+        MAP_ANONYMOUS = MAP_ANON,
+        // in core.sys.posix.sys.mman
+        // MAP_ANON = MAP_ANONYMOUS,
         MAP_VARIABLE = 0,
         MAP_HUGE_SHIFT = 26,
         MAP_HUGE_MASK = 0x3f,
@@ -460,8 +462,9 @@ else version (HPPA64)
     static if (__USE_MISC) enum
     {
         MAP_FILE = 0,
-        MAP_ANONYMOUS = 0x10,
-        MAP_ANON = MAP_ANONYMOUS,
+        MAP_ANONYMOUS = MAP_ANON,
+        // in core.sys.posix.sys.mman
+        // MAP_ANON = MAP_ANONYMOUS,
         MAP_VARIABLE = 0,
         MAP_HUGE_SHIFT = 26,
         MAP_HUGE_MASK = 0x3f,
@@ -587,8 +590,6 @@ else version (MIPS32)
         MAP_HUGETLB = 0x80000,
     }
 
-    private enum __MAP_ANONYMOUS = 0x0800;
-
     static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
 }
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/unix/sysv/linux/mips/bits/mman.h
@@ -606,8 +607,6 @@ else version (MIPS64)
         MAP_STACK = 0x40000,
         MAP_HUGETLB = 0x80000,
     }
-
-    private enum __MAP_ANONYMOUS = 0x0800;
 
     static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
 }
@@ -644,13 +643,12 @@ else
         enum MAP_TYPE = 0x0f;
 
     enum MAP_FIXED = 0x10;
-    static if (!is(typeof(__MAP_ANONYMOUS)))
-        private enum __MAP_ANONYMOUS = 0x20;
     static if (__USE_MISC) enum
     {
         MAP_FILE = 0,
-        MAP_ANONYMOUS = __MAP_ANONYMOUS,
-        MAP_ANON = MAP_ANONYMOUS,
+        MAP_ANONYMOUS = MAP_ANON,
+        // in core.sys.posix.sys.mman
+        // MAP_ANON = 0xXX,
         MAP_HUGE_SHIFT = 26,
         MAP_HUGE_MASK = 0x3f,
     }

--- a/src/core/sys/osx/sys/mman.d
+++ b/src/core/sys/osx/sys/mman.d
@@ -53,19 +53,16 @@ static if (_DARWIN_C_SOURCE)
     enum MS_DEACTIVATE = 0x0008;
 
     enum MAP_FILE = 0x0000;
-}
-    // cannot be within _DARWIN_C_SOURCE because of forward reference (Bugzilla 11301)
-    enum MAP_ANON = 0x1000;
 
 // already in core.sys.posix.sys.mman
+// enum MAP_ANON = 0x1000;
+
 // enum POSIX_MADV_NORMAL = 0;
 // enum POSIX_MADV_RANDOM = 1;
 // enum POSIX_MADV_SEQUENTIAL = 2;
 // enum POSIX_MADV_WILLNEED = 3;
 // enum POSIX_MADV_DONTNEED = 4;
 
-static if (_DARWIN_C_SOURCE)
-{
     alias MADV_NORMAL = POSIX_MADV_NORMAL;
     alias MADV_RANDOM = POSIX_MADV_RANDOM;
     alias MADV_SEQUENTIAL = POSIX_MADV_SEQUENTIAL;

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -204,29 +204,87 @@ version( linux )
 
     enum MAP_FAILED     = cast(void*) -1;
 
-    version (Alpha) enum
+    version (MICROBLAZE)
+        private enum DEFAULTS = true;
+    else version (Alpha)
     {
-        MS_ASYNC = 1,
-        MS_SYNC = 2,
-        MS_INVALIDATE = 4,
+        private enum DEFAULTS = false;
+        enum MAP_ANON = 0x10;
+        enum MS_ASYNC = 1;
+        enum MS_SYNC = 2;
+        enum MS_INVALIDATE = 4;
     }
-    else version (HPPA) enum
+    else version (SH)
+        private enum DEFAULTS = true;
+    else version (SH64)
+        private enum DEFAULTS = true;
+    else version (AArch64)
+        private enum DEFAULTS = true;
+    else version (ARM)
+        private enum DEFAULTS = true;
+    else version (S390)
+        private enum DEFAULTS = true;
+    else version (S390X)
+        private enum DEFAULTS = true;
+    else version (IA64)
+        private enum DEFAULTS = true;
+    else version (HPPA)
     {
-        MS_ASYNC = 1,
-        MS_SYNC = 2,
-        MS_INVALIDATE = 4,
+        private enum DEFAULTS = false;
+        enum MAP_ANON = 0x10;
+        enum MS_SYNC = 1;
+        enum MS_ASYNC = 2;
+        enum MS_INVALIDATE = 4;
     }
-    else version (HPPA64) enum
+    else version (HPPA64)
     {
-        MS_ASYNC = 1,
-        MS_SYNC = 2,
-        MS_INVALIDATE = 4,
+        private enum DEFAULTS = false;
+        enum MAP_ANON = 0x10;
+        enum MS_SYNC = 1;
+        enum MS_ASYNC = 2;
+        enum MS_INVALIDATE = 4;
     }
-    else enum
+    else version (M68K)
+        private enum DEFAULTS = true;
+    else version (TILE)
+        private enum DEFAULTS = true;
+    else version (X86)
+        private enum DEFAULTS = true;
+    else version (X86_64)
+        private enum DEFAULTS = true;
+    else version (MIPS32)
     {
-        MS_ASYNC = 1,
-        MS_SYNC = 4,
-        MS_INVALIDATE = 2
+        private enum DEFAULTS = false;
+        enum MAP_ANON = 0x0800;
+        enum MS_ASYNC = 1;
+        enum MS_INVALIDATE = 2;
+        enum MS_SYNC = 4;
+    }
+    else version (MIPS64)
+    {
+        private enum DEFAULTS = false;
+        enum MAP_ANON = 0x0800;
+        enum MS_ASYNC = 1;
+        enum MS_INVALIDATE = 2;
+        enum MS_SYNC = 4;
+    }
+    else version (SPARC)
+        private enum DEFAULTS = true;
+    else version (SPARC64)
+        private enum DEFAULTS = true;
+    else version (PPC)
+        private enum DEFAULTS = true;
+    else version (PPC64)
+        private enum DEFAULTS = true;
+    else
+        static assert(0, "unimplemented");
+
+    static if (DEFAULTS)
+    {
+        enum MAP_ANON = 0x20;
+        enum MS_ASYNC = 1;
+        enum MS_INVALIDATE = 2;
+        enum MS_SYNC = 4;
     }
 
     int msync(void*, size_t, int);
@@ -236,9 +294,7 @@ else version( OSX )
     enum MAP_SHARED     = 0x0001;
     enum MAP_PRIVATE    = 0x0002;
     enum MAP_FIXED      = 0x0010;
-    static import core.sys.osx.sys.mman;
-    deprecated("Please use core.sys.osx.sys.mman for non-POSIX extensions")
-    alias MAP_ANON = core.sys.osx.sys.mman.MAP_ANON;
+    enum MAP_ANON       = 0x1000;
 
     enum MAP_FAILED     = cast(void*)-1;
 
@@ -253,9 +309,7 @@ else version( FreeBSD )
     enum MAP_SHARED     = 0x0001;
     enum MAP_PRIVATE    = 0x0002;
     enum MAP_FIXED      = 0x0010;
-    static import core.sys.freebsd.sys.mman;
-    deprecated("Please use core.sys.freebsd.sys.mman for non-POSIX extensions")
-    alias MAP_ANON = core.sys.freebsd.sys.mman.MAP_ANON;
+    enum MAP_ANON       = 0x1000;
 
     enum MAP_FAILED     = cast(void*)-1;
 


### PR DESCRIPTION
- it's not Posix standard but literally supported
  by every OS and also a widely used flag, therefor
  we consider it standard

- group MS_SYNC/ASYNC/INVALIDATE flags