### PR TITLE
Issue 4650 - only scan data and bss, not const

### DIFF
--- a/src/rt/sections_win32.d
+++ b/src/rt/sections_win32.d
@@ -47,16 +47,21 @@ struct SectionGroup
 
 private:
     ModuleGroup _moduleGroup;
-    void[][1] _gcRanges;
+    void[][2] _gcRanges;
 }
 
 void initSections()
 {
     _sections._moduleGroup = ModuleGroup(getModuleInfos());
 
-    auto pbeg = cast(void*)&_xi_a;
-    auto pend = cast(void*)&_end;
-    _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
+    auto databeg = cast(void*)&_xi_a;
+    auto dataend = cast(void*)_moduleinfo_array.ptr;
+    _sections._gcRanges[0] = databeg[0 .. dataend - databeg];
+
+    // skip module info and CONST segment
+    auto bssbeg = cast(void*)&_edata;
+    auto bssend = cast(void*)&_end;
+    _sections._gcRanges[1] = bssbeg[0 .. bssend - bssbeg];
 }
 
 void finiSections()
@@ -105,7 +110,7 @@ extern(C)
     extern __gshared
     {
         int _xi_a;      // &_xi_a just happens to be start of data segment
-        //int _edata;   // &_edata is start of BSS segment
+        int _edata;     // &_edata is start of BSS segment
         int _end;       // &_end is past end of BSS
     }
 

--- a/src/rt/sections_win64.d
+++ b/src/rt/sections_win64.d
@@ -63,8 +63,10 @@ void initSections()
 {
     _sections._moduleGroup = ModuleGroup(getModuleInfos());
 
+    // the ".data" image section includes both object file sections ".data" and ".bss"
     _sections._gcRanges[0] = findImageSection(".data");
-    debug(PRINTF) printf("found .data section: [%p,+%llx]\n", _sections._gcRanges[0].ptr, cast(ulong)_sections._gcRanges[0].length);
+    debug(PRINTF) printf("found .data section: [%p,+%llx]\n", _sections._gcRanges[0].ptr,
+                         cast(ulong)_sections._gcRanges[0].length);
 }
 
 void finiSections()
@@ -140,12 +142,6 @@ extern(C)
 
         void* _deh_beg;
         void* _deh_end;
-
-        void* _data_beg;
-        void* _data_end;
-
-        void* _bss_beg;
-        void* _bss_end;
     }
 
     extern

--- a/src/rt/sections_win64.d
+++ b/src/rt/sections_win64.d
@@ -56,16 +56,20 @@ struct SectionGroup
 
 private:
     ModuleGroup _moduleGroup;
-    void[][1] _gcRanges;
+    void[][2] _gcRanges;
 }
 
 void initSections()
 {
     _sections._moduleGroup = ModuleGroup(getModuleInfos());
 
-    auto pbeg = cast(void*)&__xc_a;
-    auto pend = cast(void*)&_deh_beg;
+    auto pbeg = cast(void*)&_data_beg;
+    auto pend = cast(void*)&_data_end;
     _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
+
+    pbeg = cast(void*)&_bss_beg;
+    pend = cast(void*)&_bss_end;
+    _sections._gcRanges[1] = pbeg[0 .. pend - pbeg];
 }
 
 void finiSections()
@@ -140,9 +144,11 @@ extern(C)
         void* _deh_beg;
         void* _deh_end;
 
-        int __xc_a;      // &__xc_a just happens to be start of data segment
-        //int _edata;    // &_edata is start of BSS segment
-        //void* _deh_beg;  // &_deh_beg is past end of BSS
+        void* _data_beg;
+        void* _data_end;
+
+        void* _bss_beg;
+        void* _bss_end;
     }
 
     extern


### PR DESCRIPTION
This restricts root ranges for the GC to section ".data"  and ".bss" ~~".bss$B" and ".data$B" for Win64 (also excludes C/C++ sections)~~ and excludes the "CONST" section and a bit more for Win32.
On linux, similar functionality already exists as constant data (strings/float) is written to the .text section.

~~For Win64, this depends on https://github.com/D-Programming-Language/dmd/pull/4445~~