### PR TITLE
Make malloc and calloc @trusted

### DIFF
--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -135,25 +135,26 @@ else
     }
     else
     {
-        ///
+       ///
        int     rand();
        ///
        void    srand(uint seed);
     }
 }
 
-// We don't mark these @trusted. Given that they return a void*, one has
-// to do a pointer cast to do anything sensible with the result. Thus,
-// functions using these already have to be @trusted, allowing them to
-// call @system stuff anyway.
-///
-void*   malloc(size_t size);
-///
-void*   calloc(size_t nmemb, size_t size);
+// These are safe as they always return null or a valid void* pointer.
+@safe
+{
+    ///
+    void*   malloc(size_t size);
+    ///
+    void*   calloc(size_t nmemb, size_t size);
+}
+
 ///
 void*   realloc(void* ptr, size_t size);
 ///
-void    free(void* ptr);
+void    free(void* ptr) pure;
 
 ///
 void    abort() @safe;


### PR DESCRIPTION
`malloc` and `calloc` do not present an unsafe interface - it's reasonable to call them and do the unsafe cast or pointer slice somewhere else. Hence, they should be `@trusted`.

However, I made this PR mostly to gauge opinion about purity. I suggest these two simple heap allocators should be pure in the same vein `new` and `GC.malloc` are considered pure - memory allocation is only an observable side-effect in really niche applications that either a) inspect memory usage using OS-specific functions, or b) recover from OOM. In all other applications it is immensely practical to allow memory allocation in pure functions.

What do you think?
