### PR TITLE
Fixed ticksPerSec for OSX (in particular iOS)

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2241,7 +2241,7 @@ private:
         {
             mach_timebase_info_data_t info;
             if(mach_timebase_info(&info) == 0)
-                _ticksPerSecond = 1_000_000_000L * info.numer / info.denom;
+                _ticksPerSecond = (1_000_000_000L * info.denom) / info.numer;
         }
         else version(Posix)
         {
@@ -2492,7 +2492,7 @@ struct TickDuration
                 if(mach_timebase_info(&info))
                     ticksPerSec = 0;
                 else
-                    ticksPerSec = (1_000_000_000 * info.numer) / info.denom;
+                    ticksPerSec = (1_000_000_000L * info.denom) / info.numer;
             }
             else
                 ticksPerSec = 1_000_000;


### PR DESCRIPTION
Fix for computing ticksPerSec for OSX where the denom and numer need to be reversed.  The problem is not noticed on MacOSX because both are 1, but on iPhoneOS this is not the case.