### PR TITLE
When calling assumeSafeAppend, cache the block info for subsequent calls

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -638,7 +638,7 @@ extern(C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) /+nothrow+/
     auto size = tinext.tsize;                  // array element size
     auto cursize = arr.length * size;
     auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
-    auto bic = !isshared ? __getBlkInfo(arr.ptr) : null;
+    auto bic = isshared ? null : __getBlkInfo(arr.ptr);
     auto info = bic ? *bic : GC.query(arr.ptr);
     if(info.base && (info.attr & BlkAttr.APPENDABLE))
     {
@@ -663,8 +663,8 @@ extern(C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) /+nothrow+/
             onInvalidMemoryOperationError();
 
         // cache the block if not already done.
-        if(!isshared && !bic)
-            __insertBlkInfoCache(info, bic);
+        if (!isshared && !bic)
+            __insertBlkInfoCache(info, null);
     }
 }
 
@@ -719,7 +719,7 @@ body
 {
     // step 1, get the block
     auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
-    auto bic = !isshared ? __getBlkInfo((*p).ptr) : null;
+    auto bic = isshared ? null : __getBlkInfo((*p).ptr);
     auto info = bic ? *bic : GC.query((*p).ptr);
     auto tinext = unqualify(ti.next);
     auto size = tinext.tsize;
@@ -1516,7 +1516,7 @@ body
             if (newlength > (*p).length)
             {
                 size_t size = (*p).length * sizeelem;
-                auto   bic = !isshared ? __getBlkInfo((*p).ptr) : null;
+                auto   bic = isshared ? null : __getBlkInfo((*p).ptr);
                 auto   info = bic ? *bic : GC.query((*p).ptr);
                 if(info.base && (info.attr & BlkAttr.APPENDABLE))
                 {
@@ -1698,7 +1698,7 @@ body
             newdata = (*p).ptr;
             if (newlength > (*p).length)
             {
-                auto   bic = !isshared ? __getBlkInfo((*p).ptr) : null;
+                auto   bic = isshared ? null : __getBlkInfo((*p).ptr);
                 auto   info = bic ? *bic : GC.query((*p).ptr);
 
                 // calculate the extent of the array given the base.
@@ -1933,7 +1933,7 @@ byte[] _d_arrayappendcTX(const TypeInfo ti, ref byte[] px, size_t n)
     auto tinext = unqualify(ti.next);
     auto sizeelem = tinext.tsize;              // array element size
     auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
-    auto bic = !isshared ? __getBlkInfo(px.ptr) : null;
+    auto bic = isshared ? null : __getBlkInfo(px.ptr);
     auto info = bic ? *bic : GC.query(px.ptr);
     auto length = px.length;
     auto newlength = length + n;


### PR DESCRIPTION
Library code may conservatively call assumeSafeAppend on an array without knowing if the block will be appended to. However, if the block is not cached in the block info cache, it would not add it to the cache. This meant that code that continually calls assumeSafeAppend is constantly looking up the block info from the heap. This fixes that situation.