### PR TITLE
gc.gc: Fix out-of-bounds pagetable access

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -2944,7 +2944,7 @@ struct LargeObjectPool
         {
             assert(pagetable[i] == B_FREE);
             size_t p = 1;
-            while (p < n && pagetable[i + p] == B_FREE)
+            while (p < n && i + p < npages && pagetable[i + p] == B_FREE)
                 p++;
 
             if (p == n)


### PR DESCRIPTION
The out-of-bounds access occurs 3 lines below:

`pagetable[i + p]`

We never check that `i + p < npages`.

This patch also acts as a small optimization (don't look at the last `n-1` pages because it's impossible to find a free chunk of at least `n` pages from those positions).

Found using Vagrind: https://github.com/D-Programming-Language/druntime/pull/1197#issuecomment-85671211