### PR TITLE
Mark core.memory.GC.addRange/removeRange as nogc

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -116,10 +116,10 @@ private
     extern (C) BlkInfo_ gc_query( void* p ) pure nothrow;
 
     extern (C) void gc_addRoot( in void* p ) nothrow;
-    extern (C) void gc_addRange( in void* p, size_t sz, const TypeInfo ti = null ) nothrow;
+    extern (C) void gc_addRange( in void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
 
     extern (C) void gc_removeRoot( in void* p ) nothrow;
-    extern (C) void gc_removeRange( in void* p ) nothrow;
+    extern (C) void gc_removeRange( in void* p ) nothrow @nogc;
     extern (C) void gc_runFinalizers( in void[] segment );
 }
 
@@ -727,7 +727,7 @@ struct GC
      * // rawMemory will be recognized on collection.
      * ---
      */
-    static void addRange( in void* p, size_t sz, const TypeInfo ti = null ) nothrow /* FIXME pure */
+    static void addRange( in void* p, size_t sz, const TypeInfo ti = null ) @nogc nothrow /* FIXME pure */
     {
         gc_addRange( p, sz, ti );
     }
@@ -742,7 +742,7 @@ struct GC
      * Params:
      *  p  = A pointer to a valid memory address or to null.
      */
-    static void removeRange( in void* p ) nothrow /* FIXME pure */
+    static void removeRange( in void* p ) nothrow @nogc /* FIXME pure */
     {
         gc_removeRange( p );
     }

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -134,7 +134,7 @@ class Mutex :
     }
 
     // undocumented function for internal use
-    final void lock_nothrow() nothrow @trusted
+    final void lock_nothrow() nothrow @trusted @nogc
     {
         version( Windows )
         {
@@ -144,7 +144,11 @@ class Mutex :
         {
             int rc = pthread_mutex_lock( &m_hndl );
             if( rc )
-                throw new SyncError( "Unable to lock mutex" );
+            {
+                SyncError syncErr = cast(SyncError) cast(void*) typeid(SyncError).init;
+                syncErr.msg = "Unable to lock mutex.";
+                throw syncErr;
+            }
         }
     }
 
@@ -161,7 +165,7 @@ class Mutex :
     }
 
     // undocumented function for internal use
-    final void unlock_nothrow() nothrow @trusted
+    final void unlock_nothrow() nothrow @trusted @nogc
     {
         version( Windows )
         {
@@ -171,7 +175,11 @@ class Mutex :
         {
             int rc = pthread_mutex_unlock( &m_hndl );
             if( rc )
-                throw new SyncError( "Unable to unlock mutex" );
+            {
+                SyncError syncErr = cast(SyncError) cast(void*) typeid(SyncError).init;
+                syncErr.msg = "Unable to unlock mutex.";
+                throw syncErr;
+            }
         }
     }
 

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -432,6 +432,7 @@ else version( Posix )
 
 version( Posix )
 {
+@nogc:
     int pthread_cond_broadcast(pthread_cond_t*);
     int pthread_cond_destroy(pthread_cond_t*);
     int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -1617,9 +1617,9 @@ LONG InterlockedExchangeAdd(LPLONG Addend, LONG Value);
 LONG InterlockedCompareExchange(LONG *Destination, LONG Exchange, LONG Comperand);
 
 void InitializeCriticalSection(CRITICAL_SECTION * lpCriticalSection) @trusted;
-void EnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+void EnterCriticalSection(CRITICAL_SECTION * lpCriticalSection) @nogc;
 BOOL TryEnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
-void LeaveCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+void LeaveCriticalSection(CRITICAL_SECTION * lpCriticalSection) @nogc;
 void DeleteCriticalSection(CRITICAL_SECTION * lpCriticalSection);
 }
 

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -258,12 +258,12 @@ const uint GCVERSION = 1;       // increment every time we change interface
 // This just makes Mutex final to de-virtualize member function calls.
 final class GCMutex : Mutex
 {
-    final override void lock() nothrow @trusted
+    final override void lock() nothrow @trusted @nogc
     {
         super.lock_nothrow();
     }
 
-    final override void unlock() nothrow @trusted
+    final override void unlock() nothrow @trusted @nogc
     {
         super.unlock_nothrow();
     }
@@ -1174,7 +1174,7 @@ struct GC
     /**
      * add range to scan for roots
      */
-    void addRange(void *p, size_t sz, const TypeInfo ti = null) nothrow
+    void addRange(void *p, size_t sz, const TypeInfo ti = null) nothrow @nogc 
     {
         if (!p || !sz)
         {
@@ -1194,7 +1194,7 @@ struct GC
     /**
      * remove range
      */
-    void removeRange(void *p) nothrow
+    void removeRange(void *p) nothrow @nogc
     {
         if (!p)
         {
@@ -1564,7 +1564,7 @@ struct Gcx
     /**
      *
      */
-    void addRange(void *pbot, void *ptop, const TypeInfo ti) nothrow
+    void addRange(void *pbot, void *ptop, const TypeInfo ti) nothrow @nogc
     {
         //debug(PRINTF) printf("Thread %x ", pthread_self());
         debug(PRINTF) printf("%p.Gcx::addRange(%p, %p)\n", &this, pbot, ptop);
@@ -1575,7 +1575,7 @@ struct Gcx
     /**
      *
      */
-    void removeRange(void *pbot) nothrow
+    void removeRange(void *pbot) nothrow @nogc
     {
         //debug(PRINTF) printf("Thread %x ", pthread_self());
         debug(PRINTF) printf("Gcx.removeRange(%p)\n", pbot);

--- a/src/rt/util/container/common.d
+++ b/src/rt/util/container/common.d
@@ -22,7 +22,7 @@ void* xrealloc(void* ptr, size_t sz)
     assert(0);
 }
 
-void* xmalloc(size_t sz) nothrow
+void* xmalloc(size_t sz) nothrow @nogc
 {
     import core.exception;
     if (auto nptr = .malloc(sz))

--- a/src/rt/util/container/treap.d
+++ b/src/rt/util/container/treap.d
@@ -32,7 +32,7 @@ nothrow:
         rand48.defaultSeed();
     }
 
-    void insert(E element)
+    void insert(E element) @nogc 
     {
         root = insert(root, element);
     }
@@ -110,7 +110,7 @@ private:
     Node* root;
     Rand48 rand48;
 
-    Node* allocNode(E element)
+    Node* allocNode(E element) @nogc 
     {
         Node* node = cast(Node*)common.xmalloc(Node.sizeof);
         node.left = node.right = null;
@@ -119,7 +119,7 @@ private:
         return node;
     }
 
-    Node* insert(Node* node, E element)
+    Node* insert(Node* node, E element) @nogc 
     {
         if (!node)
             return allocNode(element);

--- a/src/rt/util/random.d
+++ b/src/rt/util/random.d
@@ -24,19 +24,19 @@ nothrow:
         popFront();
     }
 
-    auto opCall()
+    auto opCall() @nogc 
     {
         auto result = front;
         popFront();
         return result;
     }
 
-    @property uint front()
+    @property uint front() @nogc 
     {
         return cast(uint)(rng_state >> 16);
     }
 
-    void popFront()
+    void popFront() @nogc 
     {
         immutable ulong a = 25214903917;
         immutable ulong c = 11;


### PR DESCRIPTION
NOTE: this is my first druntime PR, please be sure to check it extra carefully and feel free to give me tips.

This addresses [issue 14171](https://issues.dlang.org/show_bug.cgi?id=14171). Phobos utilities that use the non-allocating GC functions in areas that should be nogc(see: std.container.array, refcounted, etc,) this should make them able to infer nogc.

I'm completely unsure of how to handle throwing errors in nogc, what I did is probably completely incorrect(? I know it shouldn't be done for exceptions - are errors an exception(heh) to this?) so I could use some advice.