### PR TITLE
Issue 14401 - typeid(shared X).init is empty for class types

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1585,7 +1585,7 @@ private:
         return cast(Mutex)_locks[1].ptr;
     }
 
-    __gshared byte[__traits(classInstanceSize, Mutex)][2] _locks;
+    __gshared void[__traits(classInstanceSize, Mutex)][2] _locks;
 
     static void initLocks()
     {

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -268,7 +268,7 @@ struct GC
     // We can't allocate a Mutex on the GC heap because we are the GC.
     // Store it in the static data segment instead.
     __gshared GCMutex gcLock;    // global lock
-    __gshared byte[__traits(classInstanceSize, GCMutex)] mutexStorage;
+    __gshared void[__traits(classInstanceSize, GCMutex)] mutexStorage;
 
     __gshared Config config;
 

--- a/src/object.di
+++ b/src/object.di
@@ -183,7 +183,7 @@ class TypeInfo_Class : TypeInfo
     @property auto info() @safe nothrow pure const { return this; }
     @property auto typeinfo() @safe nothrow pure const { return this; }
 
-    byte[]      init;   // class static initializer
+    byte[]      m_init; // class static initializer
     string      name;   // class name
     void*[]     vtbl;   // virtual function pointer table
     Interface[] interfaces;

--- a/src/object_.d
+++ b/src/object_.d
@@ -824,6 +824,8 @@ class TypeInfo_Class : TypeInfo
         return Object.sizeof;
     }
 
+    override const(void)[] init() nothrow pure const @safe { return m_init; }
+
     override @property uint flags() nothrow pure const { return 1; }
 
     override @property const(OffsetTypeInfo)[] offTi() nothrow pure const
@@ -834,7 +836,7 @@ class TypeInfo_Class : TypeInfo
     @property auto info() @safe nothrow pure const { return this; }
     @property auto typeinfo() @safe nothrow pure const { return this; }
 
-    byte[]      init;           /** class static initializer
+    byte[]      m_init;         /** class static initializer
                                  * (init.length gives size in bytes of class)
                                  */
     string      name;           /// class name
@@ -902,6 +904,20 @@ class TypeInfo_Class : TypeInfo
 }
 
 alias TypeInfo_Class ClassInfo;
+
+unittest
+{
+    // Bugzilla 14401
+    static class X
+    {
+        int a;
+    }
+
+    assert(typeid(X).init is typeid(X).m_init);
+    assert(typeid(X).init.length == typeid(const(X)).init.length);
+    assert(typeid(X).init.length == typeid(shared(X)).init.length);
+    assert(typeid(X).init.length == typeid(immutable(X)).init.length);
+}
 
 class TypeInfo_Interface : TypeInfo
 {

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -112,7 +112,7 @@ extern (C) Object _d_newclass(const ClassInfo ci)
     }
 
     // initialize it
-    (cast(byte*) p)[0 .. ci.init.length] = ci.init[];
+    p[0 .. ci.init.length] = ci.init[];
 
     debug(PRINTF) printf("initialization done\n");
     return cast(Object) p;
@@ -1412,10 +1412,10 @@ extern (C) void rt_finalize2(void* p, bool det = true, bool resetMemory = true) 
         if (ppv[1]) // if monitor is not null
             _d_monitordelete(cast(Object) p, det);
 
-        if(resetMemory)
+        if (resetMemory)
         {
-            byte[] w = (*pc).init;
-            (cast(byte*) p)[0 .. w.length] = w[];
+            auto w = (*pc).init;
+            p[0 .. w.length] = w[];
         }
     }
     catch (Exception e)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14401

`TypeInfo_Class` needs to override `init()` method for the `TypeInfo_Const` and its derived TypeInfo classes.

Now all `typeid(X).init` for any type `X` is typed as `const(void)[]`.
This is a small but necessary breaking change. If a class instance contains reference type fields, the instance image must be typed as `const(void)[]` rather than `byte[n]`.
