### PR TITLE
Add TypeInfo classes for cent/ucent.

### DIFF
--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -265,6 +265,7 @@ MANIFEST=\
 	src\rt\typeinfo\ti_byte.d \
 	src\rt\typeinfo\ti_C.d \
 	src\rt\typeinfo\ti_cdouble.d \
+	src\rt\typeinfo\ti_cent.d \
 	src\rt\typeinfo\ti_cfloat.d \
 	src\rt\typeinfo\ti_char.d \
 	src\rt\typeinfo\ti_creal.d \
@@ -281,6 +282,7 @@ MANIFEST=\
 	src\rt\typeinfo\ti_real.d \
 	src\rt\typeinfo\ti_short.d \
 	src\rt\typeinfo\ti_ubyte.d \
+	src\rt\typeinfo\ti_ucent.d \
 	src\rt\typeinfo\ti_uint.d \
 	src\rt\typeinfo\ti_ulong.d \
 	src\rt\typeinfo\ti_ushort.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -150,6 +150,7 @@ SRCS=\
 	src\rt\typeinfo\ti_byte.d \
 	src\rt\typeinfo\ti_C.d \
 	src\rt\typeinfo\ti_cdouble.d \
+	src\rt\typeinfo\ti_cent.d \
 	src\rt\typeinfo\ti_cfloat.d \
 	src\rt\typeinfo\ti_char.d \
 	src\rt\typeinfo\ti_creal.d \
@@ -166,6 +167,7 @@ SRCS=\
 	src\rt\typeinfo\ti_real.d \
 	src\rt\typeinfo\ti_short.d \
 	src\rt\typeinfo\ti_ubyte.d \
+	src\rt\typeinfo\ti_ucent.d \
 	src\rt\typeinfo\ti_uint.d \
 	src\rt\typeinfo\ti_ulong.d \
 	src\rt\typeinfo\ti_ushort.d \

--- a/src/rt/typeinfo/ti_cent.d
+++ b/src/rt/typeinfo/ti_cent.d
@@ -1,0 +1,68 @@
+/**
+ * TypeInfo support code.
+ *
+ * Copyright: Copyright Digital Mars 2004 - 2015.
+ * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Walter Bright
+ */
+
+/*          Copyright Digital Mars 2004 - 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module rt.typeinfo.ti_cent;
+
+private import rt.util.hash;
+
+static if(__traits(compiles, { cent c = 42; })):
+
+// cent
+
+class TypeInfo_zi : TypeInfo
+{
+    @trusted:
+    const:
+    pure:
+    nothrow:
+
+    override string toString() const pure nothrow @safe { return "cent"; }
+
+    override size_t getHash(in void* p)
+    {
+        return rt.util.hash.hashOf(p, cent.sizeof);
+    }
+
+    override bool equals(in void* p1, in void* p2)
+    {
+        return *cast(cent *)p1 == *cast(cent *)p2;
+    }
+
+    override int compare(in void* p1, in void* p2)
+    {
+        if (*cast(cent *)p1 < *cast(cent *)p2)
+            return -1;
+        else if (*cast(cent *)p1 > *cast(cent *)p2)
+            return 1;
+        return 0;
+    }
+
+    override @property size_t tsize() nothrow pure
+    {
+        return cent.sizeof;
+    }
+
+    override void swap(void *p1, void *p2)
+    {
+        cent t;
+
+        t = *cast(cent *)p1;
+        *cast(cent *)p1 = *cast(cent *)p2;
+        *cast(cent *)p2 = t;
+    }
+
+    override @property size_t talign() nothrow pure
+    {
+        return cent.alignof;
+    }
+}

--- a/src/rt/typeinfo/ti_ucent.d
+++ b/src/rt/typeinfo/ti_ucent.d
@@ -1,0 +1,68 @@
+/**
+ * TypeInfo support code.
+ *
+ * Copyright: Copyright Digital Mars 2004 - 2015.
+ * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Walter Bright
+ */
+
+/*          Copyright Digital Mars 2004 - 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module rt.typeinfo.ti_ucent;
+
+private import rt.util.hash;
+
+static if (__traits(compiles, { ucent uc = 42; })):
+
+// ucent
+
+class TypeInfo_zk : TypeInfo
+{
+    @trusted:
+    const:
+    pure:
+    nothrow:
+
+    override string toString() const pure nothrow @safe { return "ucent"; }
+
+    override size_t getHash(in void* p)
+    {
+        return rt.util.hash.hashOf(p, ucent.sizeof);
+    }
+
+    override bool equals(in void* p1, in void* p2)
+    {
+        return *cast(ucent *)p1 == *cast(ucent *)p2;
+    }
+
+    override int compare(in void* p1, in void* p2)
+    {
+        if (*cast(ucent *)p1 < *cast(ucent *)p2)
+            return -1;
+        else if (*cast(ucent *)p1 > *cast(ucent *)p2)
+            return 1;
+        return 0;
+    }
+
+    override @property size_t tsize() nothrow pure
+    {
+        return ucent.sizeof;
+    }
+
+    override void swap(void *p1, void *p2)
+    {
+        ucent t;
+
+        t = *cast(ucent *)p1;
+        *cast(ucent *)p1 = *cast(ucent *)p2;
+        *cast(ucent *)p2 = t;
+    }
+
+    override @property size_t talign() nothrow pure
+    {
+        return ucent.alignof;
+    }
+}


### PR DESCRIPTION
The types are defined in the spec but not yet implemented. Add the
required TypeInfo classes for supporting compilers. The classes are
guarded to prevent compile errors on non-supporting compilers.

See https://github.com/D-Programming-Language/dmd/pull/4565 for
the name mangling.