### PR TITLE
fix Issue 12891: add atomicFetchAdd to core.atomic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ trace.def
 trace.log
 Makefile
 /errno_c.obj
+make
+test/*

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -239,14 +239,6 @@ else version( AsmX86_32 )
         // +    -   *   /   %   ^^  &
         // |    ^   <<  >>  >>> ~   in
         // ==   !=  <   <=  >   >=
-        static if( op == "+=" && __traits(isIntegral, T) && is(T==V1) ) {
-            return atomicFetchAdd!(T)(val, mod);
-        }
-        else
-        static if( op == "-=" && __traits(isIntegral, T) && is(T==V1) ) {
-            return atomicFetchAdd!(T)(val, -mod);
-        }
-        else
         static if( op == "+"  || op == "-"  || op == "*"  || op == "/"   ||
                    op == "%"  || op == "^^" || op == "&"  || op == "|"   ||
                    op == "^"  || op == "<<" || op == ">>" || op == ">>>" ||
@@ -262,6 +254,14 @@ else version( AsmX86_32 )
         //
         // +=   -=  *=  /=  %=  ^^= &=
         // |=   ^=  <<= >>= >>>=    ~=
+        static if( op == "+=" && __traits(isIntegral, T) && is(T==V1) ) {
+            return atomicFetchAdd!(T)(val, mod);
+        }
+        else
+        static if( op == "-=" && __traits(isIntegral, T) && is(T==V1) ) {
+            return atomicFetchAdd!(T)(val, -mod);
+        }
+        else
         static if( op == "+=" || op == "-="  || op == "*="  || op == "/=" ||
                    op == "%=" || op == "^^=" || op == "&="  || op == "|=" ||
                    op == "^=" || op == "<<=" || op == ">>=" || op == ">>>=" ) // skip "~="

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -180,7 +180,7 @@ else version( AsmX86_32 )
         static if (T.sizeof == 1) asm pure nothrow @nogc { lock; xadd[EDX], AL; }
         else static if (T.sizeof == 2) asm pure nothrow @nogc { lock; xadd[EDX], AX; }
         else static if (T.sizeof == 4) asm pure nothrow @nogc { lock; xadd[EDX], EAX; }
-        
+            
         asm pure nothrow @nogc 
         { 
             mov mod, EAX; 
@@ -1518,20 +1518,20 @@ version( unittest )
         shared ubyte u8 = 1;
         shared ushort u16 = 2;
         shared uint u32 = 3;
-        shared ulong u64 = 4;
         shared byte i8 = 5;
         shared short i16 = 6;
         shared int i32 = 7;
-        shared long i64 = 8;
      
         assert(atomicOp!"+="(u8, 8) == 9);
         assert(atomicOp!"+="(u16, 8) == 10);
         assert(atomicOp!"+="(u32, 8) == 11);
-        assert(atomicOp!"+="(u64, 8) == 12);
         assert(atomicOp!"+="(i8, 8) == 13);
         assert(atomicOp!"+="(i16, 8) == 14);
         assert(atomicOp!"+="(i32, 8) == 15);
         version( AsmX86_64 ) {
+            shared ulong u64 = 4;
+            shared long i64 = 8;
+            assert(atomicOp!"+="(u64, 8) == 12);
             assert(atomicOp!"+="(i64, 8) == 16);
         }
     }
@@ -1541,20 +1541,20 @@ version( unittest )
         shared ubyte u8 = 1;
         shared ushort u16 = 2;
         shared uint u32 = 3;
-        shared ulong u64 = 4;
         shared byte i8 = 5;
         shared short i16 = 6;
         shared int i32 = 7;
-        shared long i64 = 8;
 
         assert(atomicOp!"-="(u8, 1) == 0);
         assert(atomicOp!"-="(u16, 1) == 1);
         assert(atomicOp!"-="(u32, 1) == 2);
-        assert(atomicOp!"-="(u64, 1) == 3);
         assert(atomicOp!"-="(i8, 1) == 4);
         assert(atomicOp!"-="(i16, 1) == 5);
         assert(atomicOp!"-="(i32, 1) == 6);
         version( AsmX86_64 ) {
+            shared ulong u64 = 4;
+            shared long i64 = 8;
+            assert(atomicOp!"-="(u64, 1) == 3);
             assert(atomicOp!"-="(i64, 1) == 7);
         }
     }
@@ -1564,20 +1564,20 @@ version( unittest )
         shared ubyte u8 = 1;
         shared ushort u16 = 2;
         shared uint u32 = 3;
-        shared ulong u64 = 4;
         shared byte i8 = 5;
         shared short i16 = 6;
         shared int i32 = 7;
-        shared long i64 = 8;
-
+        
         assert(atomicFetchAdd(u8, 8) == 9);
         assert(atomicFetchAdd(u16, 8) == 10);
         assert(atomicFetchAdd(u32, -1) == 2);
-        assert(atomicFetchAdd(u64, -1) == 3);
         assert(atomicFetchAdd(i8, -1) == 4);
         assert(atomicFetchAdd(i16, -1) == 5);
         assert(atomicFetchAdd(i32, -1) == 6);
         version( AsmX86_64 ) {
+            shared ulong u64 = 4;
+            shared long i64 = 8;
+            assert(atomicFetchAdd(u64, -1) == 3);
             assert(atomicFetchAdd(i64, -1) == 7);
         }
     }

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -159,7 +159,7 @@ else version( AsmX86_32 )
 {
     // Uses specialized asm for fast fetch and add operations
     private HeadUnshared!(T) atomicFetchAdd(T)( ref shared T val, size_t mod ) pure nothrow @nogc
-        if( __traits(isIntegral, T) )
+        if( __traits(isIntegral, T) && T.sizeof <= 4)
     in
     {
         // NOTE: 32 bit x86 systems support 8 byte CAS, which only requires
@@ -222,11 +222,11 @@ else version( AsmX86_32 )
         //
         // +=   -=  *=  /=  %=  ^^= &=
         // |=   ^=  <<= >>= >>>=    ~=
-        static if( op == "+=" && __traits(isIntegral, T) ) {
+        static if( op == "+=" && __traits(isIntegral, T) && T.sizeof <= 4) {
             return atomicFetchAdd!(T)(val, mod);
         }
         else
-        static if( op == "-=" && __traits(isIntegral, T) ) {
+        static if( op == "-=" && __traits(isIntegral, T) && T.sizeof <= 4) {
             return atomicFetchAdd!(T)(val, -mod);
         }
         else
@@ -735,12 +735,10 @@ else version( AsmX86_64 )
         // +=   -=  *=  /=  %=  ^^= &=
         // |=   ^=  <<= >>= >>>=    ~=
         static if( op == "+=" && __traits(isIntegral, T) ) {
-            pragma(msg, T, " == ", V1, " = ", is(T == V1), " (op: ", op, ")");
             return atomicFetchAdd!(T)(val, mod);
         }
         else
         static if( op == "-=" && __traits(isIntegral, T) ) {
-            pragma(msg, T, " == ", V1, " = ", is(T == V1), " (op: ", op, ")");
             return atomicFetchAdd!(T)(val, -mod);
         }
         else

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -174,7 +174,7 @@ else version( AsmX86_32 )
         size_t tmp = mod; // convert all operands to size_t
         asm pure nothrow @nogc
         {
-            mov RAX, tmp;
+            mov EAX, tmp;
             mov EDX, val;
         }
         static if (T.sizeof == 1) asm pure nothrow @nogc { lock; xadd[EDX], AL; }

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -158,18 +158,8 @@ version( CoreDdoc )
 else version( AsmX86_32 )
 {
     // Uses specialized asm for fast fetch and add operations
-    private HeadUnshared!(T) atomicFetchAdd(T)( ref shared T val, size_t mod ) pure nothrow @nogc
+    private HeadUnshared!(T) atomicFetchAdd(T)( ref shared T val, T mod ) pure nothrow @nogc
         if( __traits(isIntegral, T) && T.sizeof <= 4)
-    in
-    {
-        // NOTE: 32 bit x86 systems support 8 byte CAS, which only requires
-        //       4 byte alignment, so use size_t as the align type here.
-        static if( T.sizeof > size_t.sizeof )
-            assert( atomicValueIsProperlyAligned!(size_t)( cast(size_t) &val ) );
-        else
-            assert( atomicValueIsProperlyAligned!(T)( cast(size_t) &val ) );
-    }
-    body
     {
         size_t tmp = mod; // convert all operands to size_t
         asm pure nothrow @nogc
@@ -187,6 +177,12 @@ else version( AsmX86_32 )
         }
 
         return cast(T)(tmp + mod);
+    }
+
+    private HeadUnshared!(T) atomicSubFetch(T)( ref shared T val, size_t mod ) pure nothrow @nogc
+        if( __traits(isIntegral, T) && T.sizeof <= 4)
+    {
+        return atomicFetchAdd(val, -mod);
     }
 
     HeadUnshared!(T) atomicOp(string op, T, V1)( ref shared T val, V1 mod ) pure nothrow @nogc

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -239,6 +239,14 @@ else version( AsmX86_32 )
         // +    -   *   /   %   ^^  &
         // |    ^   <<  >>  >>> ~   in
         // ==   !=  <   <=  >   >=
+        static if( op == "+=" && __traits(isIntegral, T) && is(T==V1) ) {
+            return atomicFetchAdd!(T)(val, mod);
+        }
+        else
+        static if( op == "-=" && __traits(isIntegral, T) && is(T==V1) ) {
+            return atomicFetchAdd!(T)(val, -mod);
+        }
+        else
         static if( op == "+"  || op == "-"  || op == "*"  || op == "/"   ||
                    op == "%"  || op == "^^" || op == "&"  || op == "|"   ||
                    op == "^"  || op == "<<" || op == ">>" || op == ">>>" ||

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -641,7 +641,6 @@ else version( AsmX86_64 )
     }
     body
     {
-        writeln("atomicFetchAdd");
         HeadUnshared!(T) oval = void;
         static if (T.sizeof == 1)
         {

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -56,6 +56,70 @@ version( AsmX86 )
     {
         return addr % T.sizeof == 0;
     }
+
+    // Uses specialized asm for fast fetch and add operations
+    HeadUnshared!(T) atomicFetchAdd(T)( ref shared T val, T mod ) pure nothrow @nogc
+        if( __traits(isIntegral, T) )
+    in
+    {
+        // NOTE: 32 bit x86 systems support 8 byte CAS, which only requires
+        //       4 byte alignment, so use size_t as the align type here.
+        static if( T.sizeof > size_t.sizeof )
+            assert( atomicValueIsProperlyAligned!(size_t)( cast(size_t) &val ) );
+        else
+            assert( atomicValueIsProperlyAligned!(T)( cast(size_t) &val ) );
+    }
+    body
+    {
+        HeadUnshared!(T) oval = void;
+        static if (T.sizeof == 1)
+        {
+            asm pure nothrow @nogc
+            {
+                mov AL, mod;
+                mov RDX, val;
+                lock;
+                xadd[RDX], AL;
+                mov oval, AL;
+            }
+        }
+        else static if (T.sizeof == 2)
+        {
+            asm pure nothrow @nogc
+            {
+                mov AX, mod;
+                mov RDX, val;
+                lock;
+                xadd[RDX], AX;
+                mov oval, AX;
+            }
+        }
+        else static if (T.sizeof == 4)
+        {
+            asm pure nothrow @nogc
+            {
+                mov EAX, mod;
+                mov RDX, val;
+                lock;
+                xadd[RDX], EAX;
+                mov oval, EAX;
+            }
+        }
+        else static if (T.sizeof == 8)
+        {
+            asm pure nothrow @nogc
+            {
+                mov RAX, mod;
+                mov RDX, val;
+                lock;
+                xadd[RDX], RAX;
+                mov oval, RAX;
+            }
+        }
+ 
+        oval += mod;
+        return oval;
+    }
 }
 
 
@@ -628,72 +692,6 @@ else version( AsmX86_32 )
 }
 else version( AsmX86_64 )
 {
-    HeadUnshared!(T) atomicFetchAdd(T)( ref shared T val, T mod ) pure nothrow @nogc
-        if( __traits(isIntegral, T) )
-    in
-    {
-        // NOTE: 32 bit x86 systems support 8 byte CAS, which only requires
-        //       4 byte alignment, so use size_t as the align type here.
-        static if( T.sizeof > size_t.sizeof )
-            assert( atomicValueIsProperlyAligned!(size_t)( cast(size_t) &val ) );
-        else
-            assert( atomicValueIsProperlyAligned!(T)( cast(size_t) &val ) );
-    }
-    body
-    {
-        HeadUnshared!(T) oval = void;
-        static if (T.sizeof == 1)
-        {
-            asm pure nothrow @nogc
-            {
-                mov AL, mod;
-                mov RDX, val;
-                lock;
-                xadd[RDX], AL;
-                mov oval, AL;
-            }
-        }
-        else static if (T.sizeof == 2)
-        {
-            asm pure nothrow @nogc
-            {
-                mov AX, mod;
-                mov RDX, val;
-                lock;
-                xadd[RDX], AX;
-                mov oval, AX;
-            }
-        }
-        else static if (T.sizeof == 4)
-        {
-            asm pure nothrow @nogc
-            {
-                mov EAX, mod;
-                mov RDX, val;
-                lock;
-                xadd[RDX], EAX;
-                mov oval, EAX;
-            }
-        }
-        else static if (T.sizeof == 8)
-        {
-            asm pure nothrow @nogc
-            {
-                mov RAX, mod;
-                mov RDX, val;
-                lock;
-                xadd[RDX], RAX;
-                mov oval, RAX;
-            }
-        }
- 
-        oval += mod;
-        return oval;
-    }
-
-
-
-
     HeadUnshared!(T) atomicOp(string op, T, V1)( ref shared T val, V1 mod ) pure nothrow @nogc
         if( __traits( compiles, mixin( "*cast(T*)&val" ~ op ~ "mod" ) ) )
     in
@@ -727,8 +725,12 @@ else version( AsmX86_64 )
         //
         // +=   -=  *=  /=  %=  ^^= &=
         // |=   ^=  <<= >>= >>>=    ~=
-        static if( op == "+=" && __traits(isIntegral, T) && __traits(isSame,T,V1) ) {
+        static if( op == "+=" && __traits(isIntegral, T) && is(T==V1) ) {
             return atomicFetchAdd!(T)(val, mod);
+        }
+        else
+        static if( op == "-=" && __traits(isIntegral, T) && is(T==V1) ) {
+            return atomicFetchAdd!(T)(val, -mod);
         }
         else
         static if( op == "+=" || op == "-="  || op == "*="  || op == "/=" ||
@@ -1519,6 +1521,54 @@ version( unittest )
         assert(atomicOp!"+="(i8, 8) == 13);
         assert(atomicOp!"+="(i16, 8) == 14);
         assert(atomicOp!"+="(i32, 8) == 15);
-        assert(atomicOp!"+="(i64, 8) == 16);
+        version( AsmX86_64 ) {
+            assert(atomicOp!"+="(i64, 8) == 16);
+        }
+    }
+
+    unittest
+    {
+        shared ubyte u8 = 1;
+        shared ushort u16 = 2;
+        shared uint u32 = 3;
+        shared ulong u64 = 4;
+        shared byte i8 = 5;
+        shared short i16 = 6;
+        shared int i32 = 7;
+        shared long i64 = 8;
+
+        assert(atomicOp!"-="(u8, 1) == 0);
+        assert(atomicOp!"-="(u16, 1) == 1);
+        assert(atomicOp!"-="(u32, 1) == 2);
+        assert(atomicOp!"-="(u64, 1) == 3);
+        assert(atomicOp!"-="(i8, 1) == 4);
+        assert(atomicOp!"-="(i16, 1) == 5);
+        assert(atomicOp!"-="(i32, 1) == 6);
+        version( AsmX86_64 ) {
+            assert(atomicOp!"-="(i64, 1) == 7);
+        }
+    }
+
+    unittest
+    {
+        shared ubyte u8 = 1;
+        shared ushort u16 = 2;
+        shared uint u32 = 3;
+        shared ulong u64 = 4;
+        shared byte i8 = 5;
+        shared short i16 = 6;
+        shared int i32 = 7;
+        shared long i64 = 8;
+
+        assert(atomicFetchAdd(u8, 8) == 9);
+        assert(atomicFetchAdd(u16, 8) == 10);
+        assert(atomicFetchAdd(u32, -1) == 2);
+        assert(atomicFetchAdd(u64, -1) == 3);
+        assert(atomicFetchAdd(i8, -1) == 4);
+        assert(atomicFetchAdd(i16, -1) == 5);
+        assert(atomicFetchAdd(i32, -1) == 6);
+        version( AsmX86_64 ) {
+            assert(atomicFetchAdd(i64, -1) == 7);
+        }
     }
 }


### PR DESCRIPTION
This is the placeholder pull request for the work on improving performance around fetchAdd atomic operations. This has a new implementation for += and -= atomicOp and provides a new method atomicFetchAdd. I'd debate if we require atomicFetchSub for this feature, but I'm open to thoughts.

Ideally, I need help for someone to benchmark this PR to see if it does indeed improve performance on x86 and x86_x64.

https://issues.dlang.org/show_bug.cgi?id=12891