### PR TITLE
fix Issue 14423 - struct destructors not finalized for AA values 

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -206,7 +206,7 @@ class TypeInfo_Class : TypeInfo
     void*       deallocator;
     OffsetTypeInfo[] m_offTi;
     void*       defaultConstructor;
-    immutable(void)*    m_rtInfo;     // data for precise GC
+    immutable(void)*    m_RTInfo;     // data for precise GC
 
     static const(TypeInfo_Class) find(in char[] classname);
     Object create() const;
@@ -234,11 +234,16 @@ class TypeInfo_Struct : TypeInfo
     enum StructFlags : uint
     {
         hasPointers = 0x1,
+        isDynamicType = 0x2, // built at runtime, needs type info in xdtor
     }
     StructFlags m_flags;
   }
-    void function(void*)                    xdtor;
-    void function(void*)                    xpostblit;
+    union
+    {
+        void function(void*)                xdtor;
+        void function(void*, const TypeInfo_Struct ti) xdtorti;
+    }
+  void function(void*)                    xpostblit;
 
     uint m_align;
 
@@ -247,7 +252,7 @@ class TypeInfo_Struct : TypeInfo
         TypeInfo m_arg1;
         TypeInfo m_arg2;
     }
-    immutable(void)* m_rtInfo;
+    immutable(void)* m_RTInfo;
 }
 
 class TypeInfo_Tuple : TypeInfo
@@ -394,7 +399,7 @@ extern (C)
     // from druntime/src/rt/aaA.d
 
     // size_t _aaLen(in void* p) pure nothrow @nogc;
-    private void* _aaGetX(void** paa, const TypeInfo keyti, in size_t valuesize, in void* pkey) pure nothrow;
+    private void* _aaGetY(void** paa, const TypeInfo_AssociativeArray ti, in size_t valuesize, in void* pkey) pure nothrow;
     // inout(void)* _aaGetRvalueX(inout void* p, in TypeInfo keyti, in size_t valuesize, in void* pkey);
     inout(void)[] _aaValues(inout void* p, in size_t keysize, in size_t valuesize, const TypeInfo tiValArray) pure nothrow;
     inout(void)[] _aaKeys(inout void* p, in size_t keysize, const TypeInfo tiKeyArray) pure nothrow;
@@ -468,7 +473,7 @@ V[K] dup(T : V[K], K, V)(T aa)
     {
         import core.stdc.string : memcpy;
 
-        void* pv = _aaGetX(cast(void**)&result, typeid(K), V.sizeof, &k);
+        void* pv = _aaGetY(cast(void**)&result, typeid(V[K]), V.sizeof, &k);
         memcpy(pv, &v, V.sizeof);
         return *cast(V*)pv;
     }

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -183,7 +183,7 @@ extern (C) void _d_delstruct(void** p, TypeInfo_Struct inf)
     {
         debug(PRINTF) printf("_d_delstruct(%p, %p)\n", *p, cast(void*)inf);
 
-        inf.destroy(p);
+        inf.destroy(*p);
         GC.free(*p);
         *p = null;
     }


### PR DESCRIPTION
This builds an appropriate TypeInfo_Struct for aaA.Entry at runtime whenever a new Impl is created.
I've removed the old unused _aaGetX as it doesn't provide enough type info, and disabled the future yet unused _aaGetZ for the same reason.