### PR TITLE
Fix FP_ILOGB0 and FP_ILOGBNAN constants for FreeBSD

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -37,10 +37,20 @@ enum float INFINITY       = float.infinity;
 ///
 enum float NAN            = float.nan;
 
-///
-enum int FP_ILOGB0        = int.min;
-///
-enum int FP_ILOGBNAN      = int.min;
+version (FreeBSD)
+{
+    ///
+    enum int FP_ILOGB0        = -int.max;
+    ///
+    enum int FP_ILOGBNAN      = int.max;
+}
+else
+{
+    ///
+    enum int FP_ILOGB0        = int.min;
+    ///
+    enum int FP_ILOGBNAN      = int.min;
+}
 
 ///
 enum int MATH_ERRNO       = 1;


### PR DESCRIPTION
The constants are wrong for FreeBSD, and we see issues with it in https://github.com/D-Programming-Language/phobos/pull/3161

The FreeBSD choice of constants is also C99 compliant. 