### PR TITLE
better AA benchmarks

### DIFF
--- a/benchmark/aabench/bulk.d
+++ b/benchmark/aabench/bulk.d
@@ -9,11 +9,9 @@ import std.random, std.typetuple, std.conv;
 
 version (VERBOSE) import std.datetime, std.stdio;
 
-alias TypeTuple!(ubyte, short, uint, long, void*, Object, ubyte[16], ubyte[64],
-                 ubyte[256], ubyte[1024], ubyte[4096], ubyte[16384]
-) ValueTuple;
+alias ValueTuple = TypeTuple!(void[0], uint, void*, Object, ubyte[16], ubyte[64]);
 
-size_t Size = 2 ^^ 20;
+size_t Size = 2 ^^ 16;
 size_t trot;
 
 void runTest(V)(ref V v)
@@ -44,7 +42,7 @@ void runTest(V)(ref V v)
     V[size_t] aa;
 
     start();
-    foreach(k; 0 .. Size / V.sizeof)
+    foreach(k; 0 .. Size)
     {
         aa[k] = v;
     }
@@ -52,7 +50,7 @@ void runTest(V)(ref V v)
     aa.destroy();
 
     start();
-    foreach_reverse(k; 0 .. Size / V.sizeof)
+    foreach_reverse(k; 0 .. Size)
     {
         aa[k] = v;
     }
@@ -60,7 +58,7 @@ void runTest(V)(ref V v)
     aa.destroy();
 
     start();
-    foreach(ref k; 0 .. trot * (Size / V.sizeof))
+    foreach(ref k; 0 .. trot * Size)
     {
         aa[k] = v;
         k += trot - 1;
@@ -69,7 +67,7 @@ void runTest(V)(ref V v)
     aa.destroy();
 
     start();
-    foreach_reverse(ref k; 0 .. trot * (Size / V.sizeof))
+    foreach_reverse(ref k; 0 .. trot * Size)
     {
         k -= trot - 1;
         aa[k] = v;
@@ -82,13 +80,7 @@ void runTest(V)(ref V v)
 
 void main(string[] args)
 {
-    if (args.length > 1)
-        Size = 1 << to!int(args[1]);
-
-    version (RANDOMIZE)
-        trot = uniform(1, 200);
-    else
-        trot = 7;
+    trot = 7;
 
     version (VERBOSE)
     {

--- a/benchmark/aabench/int.d
+++ b/benchmark/aabench/int.d
@@ -1,0 +1,21 @@
+/**
+ * Benchmark int hashing.
+ *
+ * Copyright: Copyright Martin Nowak 2011 - 2015.
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:    Martin Nowak
+ */
+import std.random;
+
+void main(string[] args)
+{
+    auto rnd = Xorshift32(33);
+
+    int[int] aa;
+    foreach (_; 0 .. 10)
+        foreach (__; 0 .. 100_000)
+            ++aa[uniform(0, 100_000, rnd)];
+
+    if (aa.length != 99998)
+        assert(0);
+}

--- a/benchmark/aabench/obj.d
+++ b/benchmark/aabench/obj.d
@@ -1,0 +1,30 @@
+/**
+ * Benchmark class hashing.
+ *
+ * Copyright: Copyright Martin Nowak 2011 - 2015.
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:    Martin Nowak
+ */
+import std.random;
+
+void main(string[] args)
+{
+    auto rnd = Xorshift32(33);
+
+    Object[Object] aa;
+    auto objs = new Object[](32768);
+    foreach (ref o; objs)
+        o = new Object;
+
+    foreach (_; 0 .. 10)
+    {
+        foreach (__; 0 .. 100_000)
+        {
+            auto k = objs[uniform(0, objs.length, rnd)];
+            auto v = objs[uniform(0, objs.length, rnd)];
+            aa[k] = v;
+        }
+    }
+    if (aa.length != objs.length)
+        assert(0);
+}

--- a/benchmark/aabench/ptr.d
+++ b/benchmark/aabench/ptr.d
@@ -1,0 +1,25 @@
+/**
+ * Benchmark ptr hashing.
+ *
+ * Copyright: Copyright Martin Nowak 2011 - 2015.
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:    Martin Nowak
+ */
+import std.random;
+
+void main(string[] args)
+{
+    auto rnd = Xorshift32(33);
+
+    int[int* ] aa;
+    auto keys = new int*[](32768);
+    foreach (ref k; keys)
+        k = new int;
+
+    foreach (_; 0 .. 10)
+        foreach (__; 0 .. 100_000)
+            ++aa[keys[uniform(0, keys.length, rnd)]];
+
+    if (aa.length != keys.length)
+        assert(0);
+}

--- a/benchmark/aabench/resize.d
+++ b/benchmark/aabench/resize.d
@@ -8,11 +8,11 @@
 
 import std.random;
 
-enum Count = 1_000;
+enum Count = 256;
 enum MinSize = 512;
 enum MaxSize = 16_384;
 
-void runTest(Random gen)
+void runTest(RNG)(RNG gen)
 {
     bool[uint] aa;
 
@@ -43,15 +43,14 @@ void runTest(Random gen)
 
         auto nsize = uniform(MinSize, MaxSize, gen);
         diff = nsize - aa.length;
-
     } while (--cnt);
 }
 
 void main()
 {
     version (RANDOMIZE)
-        auto gen = Random(unpredictableSeed);
+        auto gen = Xorshift32(unpredictableSeed);
     else
-        auto gen = Random(12);
+        auto gen = Xorshift32(33);
     runTest(gen);
 }

--- a/benchmark/aabench/string.d
+++ b/benchmark/aabench/string.d
@@ -1,25 +1,27 @@
 /**
  * Benchmark string hashing.
  *
- * Copyright: Copyright Martin Nowak 2011 - 2011.
+ * Copyright: Copyright Martin Nowak 2011 - 2015.
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Authors:    Martin Nowak
  */
 import std.array, std.file, std.path;
 
-void runTest(string[] words)
+void runTest(R)(R words)
 {
     size_t[string] aa;
 
-    foreach(word; words)
-        ++aa[word];
+    foreach (_; 0 .. 10)
+        foreach (word; words)
+            ++aa[word];
 
-    assert(aa.length == 20795);
+    if (aa.length != 24900)
+        assert(0);
 }
 
 void main(string[] args)
 {
     auto path = args.length > 1 ? args[1] : "extra-files/dante.txt";
-    auto words = split(std.file.readText(path));
+    auto words = splitter(cast(string) read(path), ' ');
     runTest(words);
 }


### PR DESCRIPTION
- cover different key types (int, obj, ptr)
- fix string to be AA limited, instead of benchmarking text splitting