### PR TITLE
Collapse all redundant version(OS) blocks

### DIFF
--- a/src/core/sys/posix/arpa/inet.d
+++ b/src/core/sys/posix/arpa/inet.d
@@ -199,23 +199,4 @@ NOTE: The following must must be defined in core.sys.posix.arpa.inet to break
 INET6_ADDRSTRLEN // from core.sys.posix.netinet.in_
 */
 
-version( linux )
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version( OSX )
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version( FreeBSD )
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version( Solaris )
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version( Android )
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
+enum INET6_ADDRSTRLEN = 46;

--- a/src/core/sys/posix/grp.d
+++ b/src/core/sys/posix/grp.d
@@ -38,59 +38,12 @@ group* getgrnam(in char*);
 group* getgrgid(gid_t);
 */
 
-version( linux )
+struct group
 {
-    struct group
-    {
-        char*   gr_name;
-        char*   gr_passwd;
-        gid_t   gr_gid;
-        char**  gr_mem;
-    }
-}
-else version( OSX )
-{
-    struct group
-    {
-        char*   gr_name;
-        char*   gr_passwd;
-        gid_t   gr_gid;
-        char**  gr_mem;
-    }
-}
-else version( FreeBSD )
-{
-    struct group
-    {
-        char*   gr_name;
-        char*   gr_passwd;
-        gid_t   gr_gid;
-        char**  gr_mem;
-    }
-}
-else version( Solaris )
-{
-    struct group
-    {
-        char*   gr_name;
-        char*   gr_passwd;
-        gid_t   gr_gid;
-        char**  gr_mem;
-    }
-}
-else version( Android )
-{
-    struct group
-    {
-        char*   gr_name;
-        char*   gr_passwd;
-        gid_t   gr_gid;
-        char**  gr_mem;
-    }
-}
-else
-{
-    static assert(false, "Unsupported platform");
+    char*   gr_name;
+    char*   gr_passwd;
+    gid_t   gr_gid;
+    char**  gr_mem;
 }
 
 group* getgrnam(in char*);

--- a/src/core/sys/posix/netinet/in_.d
+++ b/src/core/sys/posix/netinet/in_.d
@@ -972,23 +972,4 @@ else version( Android )
 IPPROTO_RAW
 */
 
-version( linux )
-{
-    enum uint IPPROTO_RAW = 255;
-}
-else version( OSX )
-{
-    enum uint IPPROTO_RAW = 255;
-}
-else version( FreeBSD )
-{
-    enum uint IPPROTO_RAW = 255;
-}
-else version( Solaris )
-{
-    enum uint IPPROTO_RAW = 255;
-}
-else version( Android )
-{
-    enum uint IPPROTO_RAW = 255;
-}
+enum uint IPPROTO_RAW = 255;

--- a/src/core/sys/posix/netinet/tcp.d
+++ b/src/core/sys/posix/netinet/tcp.d
@@ -26,23 +26,4 @@ extern (C):
 TCP_NODELAY
 */
 
-version( linux )
-{
-    enum TCP_NODELAY = 1;
-}
-else version( OSX )
-{
-    enum TCP_NODELAY = 1;
-}
-else version( FreeBSD )
-{
-    enum TCP_NODELAY = 1;
-}
-else version( Solaris )
-{
-    enum TCP_NODELAY = 1;
-}
-else version( Android )
-{
-    enum TCP_NODELAY = 1;
-}
+enum TCP_NODELAY = 1;

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -993,52 +993,9 @@ int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
 int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 */
 
-version (linux)
-{
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
-    int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
-    int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
-}
-else version( FreeBSD )
-{
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
-    int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
-    int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
-}
-else version( OSX )
-{
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
-    int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
-    int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
-}
-else version (Solaris)
-{
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
-    int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
-    int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
-}
-else version (Android)
-{
-    int pthread_condattr_getpshared(pthread_condattr_t*, int*);
-    int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(pthread_rwlockattr_t*, int*);
-    int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
+int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
+int pthread_condattr_setpshared(pthread_condattr_t*, int);
+int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
+int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
+int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
+int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);

--- a/src/core/sys/posix/sched.d
+++ b/src/core/sys/posix/sched.d
@@ -135,30 +135,7 @@ version( Posix )
 int sched_yield();
 */
 
-version( linux )
-{
-    int sched_yield();
-}
-else version( OSX )
-{
-    int sched_yield();
-}
-else version( FreeBSD )
-{
-    int sched_yield();
-}
-else version (Solaris)
-{
-    int sched_yield();
-}
-else version (Android)
-{
-    int sched_yield();
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
+int sched_yield();
 
 //
 // Scheduling (TPS)

--- a/src/core/sys/posix/semaphore.d
+++ b/src/core/sys/posix/semaphore.d
@@ -128,27 +128,4 @@ version( Posix )
 int sem_timedwait(sem_t*, in timespec*);
 */
 
-version( linux )
-{
-    int sem_timedwait(sem_t*, in timespec*);
-}
-else version( OSX )
-{
-    int sem_timedwait(sem_t*, in timespec*);
-}
-else version( FreeBSD )
-{
-    int sem_timedwait(sem_t*, in timespec*);
-}
-else version (Solaris)
-{
-    int sem_timedwait(sem_t*, in timespec*);
-}
-else version( Android )
-{
-    int sem_timedwait(sem_t*, in timespec*);
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
+int sem_timedwait(sem_t*, in timespec*);

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -2019,32 +2019,5 @@ int pthread_kill(pthread_t, int);
 int pthread_sigmask(int, in sigset_t*, sigset_t*);
 */
 
-version( linux )
-{
-    int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
-}
-else version( OSX )
-{
-    int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
-}
-else version( FreeBSD )
-{
-    int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
-}
-else version (Solaris)
-{
-    int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
-}
-else version( Android )
-{
-    int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
+int pthread_kill(pthread_t, int);
+int pthread_sigmask(int, in sigset_t*, sigset_t*);

--- a/src/core/sys/posix/stdlib.d
+++ b/src/core/sys/posix/stdlib.d
@@ -104,41 +104,10 @@ int setenv(in char*, in char*, int);
 int unsetenv(in char*);
 */
 
-version( linux )
-{
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+int setenv(in char*, in char*, int);
+int unsetenv(in char*);
 
-    void* valloc(size_t); // LEGACY non-standard
-}
-else version( OSX )
-{
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
-
-    void* valloc(size_t); // LEGACY non-standard
-}
-else version( FreeBSD )
-{
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
-
-    void* valloc(size_t); // LEGACY non-standard
-}
-else version( Android )
-{
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
-
-    void* valloc(size_t);
-}
-else version( Solaris )
-{
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
-
-    void* valloc(size_t); // LEGACY non-standard
-}
+void* valloc(size_t); // LEGACY non-standard
 
 //
 // Thread-Safe Functions (TSF)

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -98,45 +98,10 @@ PROT_EXEC
 PROT_NONE
 */
 
-version( linux )
-{
-    enum PROT_NONE      = 0x0;
-    enum PROT_READ      = 0x1;
-    enum PROT_WRITE     = 0x2;
-    enum PROT_EXEC      = 0x4;
-}
-else version( OSX )
-{
-    enum PROT_NONE      = 0x00;
-    enum PROT_READ      = 0x01;
-    enum PROT_WRITE     = 0x02;
-    enum PROT_EXEC      = 0x04;
-}
-else version( FreeBSD )
-{
-    enum PROT_NONE      = 0x00;
-    enum PROT_READ      = 0x01;
-    enum PROT_WRITE     = 0x02;
-    enum PROT_EXEC      = 0x04;
-}
-else version (Solaris)
-{
-    enum PROT_NONE = 0x00;
-    enum PROT_READ = 0x01;
-    enum PROT_WRITE = 0x02;
-    enum PROT_EXEC = 0x04;
-}
-else version (Android)
-{
-    enum PROT_NONE = 0x00;
-    enum PROT_READ = 0x01;
-    enum PROT_WRITE = 0x02;
-    enum PROT_EXEC = 0x04;
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
+enum PROT_NONE  = 0x0;
+enum PROT_READ  = 0x1;
+enum PROT_WRITE = 0x2;
+enum PROT_EXEC  = 0x4;
 
 //
 // Memory Mapped Files, Shared Memory Objects, or Typed Memory Objects (MC3)
@@ -455,35 +420,8 @@ int mlock(in void*, size_t);
 int munlock(in void*, size_t);
 */
 
-version( linux )
-{
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
-}
-else version( OSX )
-{
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
-}
-else version( FreeBSD )
-{
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
-}
-else version (Solaris)
-{
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
-}
-else version (Android)
-{
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
+int mlock(in void*, size_t);
+int munlock(in void*, size_t);
 
 //
 // Memory Protection (MPR)

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -326,45 +326,10 @@ tm*   gmtime_r(in time_t*, tm*);
 tm*   localtime_r(in time_t*, tm*);
 */
 
-version( linux )
-{
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
-}
-else version( OSX )
-{
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
-}
-else version( FreeBSD )
-{
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
-}
-else version (Solaris)
-{
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm* gmtime_r(in time_t*, tm*);
-    tm* localtime_r(in time_t*, tm*);
-}
-else version (Android)
-{
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm* gmtime_r(in time_t*, tm*);
-    tm* localtime_r(in time_t*, tm*);
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
+char* asctime_r(in tm*, char*);
+char* ctime_r(in time_t*, char*);
+tm*   gmtime_r(in time_t*, tm*);
+tm*   localtime_r(in time_t*, tm*);
 
 //
 // XOpen (XSI)

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -1086,26 +1086,7 @@ else version( Solaris )
 int fsync(int);
 */
 
-version( linux )
-{
-    int fsync(int) @trusted;
-}
-else version( OSX )
-{
-    int fsync(int) @trusted;
-}
-else version( FreeBSD )
-{
-    int fsync(int) @trusted;
-}
-else version( Android )
-{
-    int fsync(int) @trusted;
-}
-else version( Solaris )
-{
-    int fsync(int) @trusted;
-}
+int fsync(int) @trusted;
 
 //
 // Synchronized I/O (SIO)

--- a/src/core/sys/posix/utime.d
+++ b/src/core/sys/posix/utime.d
@@ -35,53 +35,10 @@ struct utimbuf
 int utime(in char*, in utimbuf*);
 */
 
-version( linux )
+struct utimbuf
 {
-    struct utimbuf
-    {
-        time_t  actime;
-        time_t  modtime;
-    }
-
-    int utime(in char*, in utimbuf*);
+    time_t  actime;
+    time_t  modtime;
 }
-else version( OSX )
-{
-    struct utimbuf
-    {
-        time_t  actime;
-        time_t  modtime;
-    }
 
-    int utime(in char*, in utimbuf*);
-}
-else version( FreeBSD )
-{
-    struct utimbuf
-    {
-        time_t  actime;
-        time_t  modtime;
-    }
-
-    int utime(in char*, in utimbuf*);
-}
-else version( Solaris )
-{
-    struct utimbuf
-    {
-        time_t  actime;
-        time_t  modtime;
-    }
-
-    int utime(in char*, in utimbuf*);
-}
-else version( Android )
-{
-    struct utimbuf
-    {
-        time_t  actime;
-        time_t  modtime;
-    }
-
-    int utime(in char*, in utimbuf*);
-}
+int utime(in char*, in utimbuf*);


### PR DESCRIPTION
This was done in #1069 but proved controversial, so I've spun it off into this PR so as not to block the rest of the changes in that PR.

If reviewers can provide a reason why any particular version block might be needed in the future, say because some future OS we'd like to support varies, I'll add a comment indicating that instead and leave that block in.  Otherwise, I'd rather clean these up and not have this unnecessary boilerplate.