### PR TITLE
Copy object.di from object_.d

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -145,6 +145,10 @@ $(IMPDIR)/core/sync/%.di : src/core/sync/%.d
 
 copy: $(COPY)
 
+$(IMPDIR)/object.di : src/object_.d
+	@mkdir -p `dirname $@`
+	cp $< $@
+
 $(IMPDIR)/%.di : src/%.di
 	@mkdir -p `dirname $@`
 	cp $< $@

--- a/src/object.di
+++ b/src/object.di
@@ -49,13 +49,7 @@ class Object
     static Object factory(string classname);
 }
 
-bool opEquals(const Object lhs, const Object rhs)
-{
-    // A hack for the moment.
-    return opEquals(cast()lhs, cast()rhs);
-}
-
-bool opEquals(Object lhs, Object rhs)
+auto opEquals(Object lhs, Object rhs)
 {
     // If aliased to the same object or both null => equal
     if (lhs is rhs) return true;
@@ -75,6 +69,12 @@ bool opEquals(Object lhs, Object rhs)
 
     // General case => symmetric calls to method opEquals
     return lhs.opEquals(rhs) && rhs.opEquals(lhs);
+}
+
+auto opEquals(const Object lhs, const Object rhs)
+{
+    // A hack for the moment.
+    return opEquals(cast()lhs, cast()rhs);
 }
 
 void setSameMutex(shared Object ownee, shared Object owner);

--- a/src/object_.d
+++ b/src/object_.d
@@ -30,8 +30,6 @@ private
     debug(PRINTF) import core.stdc.stdio;
 
     extern (C) Object _d_newclass(const TypeInfo_Class ci);
-    extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow;
-    extern (C) size_t _d_arraysetcapacity(const TypeInfo ti, size_t newcapacity, void *arrptr) pure nothrow;
     extern (C) void rt_finalize(void *data, bool det=true);
 }
 
@@ -1310,6 +1308,197 @@ class MemberInfo_function : MemberInfo
 
 
 ///////////////////////////////////////////////////////////////////////////////
+// ModuleInfo
+///////////////////////////////////////////////////////////////////////////////
+
+
+enum
+{
+    MIctorstart  = 0x1,   // we've started constructing it
+    MIctordone   = 0x2,   // finished construction
+    MIstandalone = 0x4,   // module ctor does not depend on other module
+                        // ctors being done first
+    MItlsctor    = 8,
+    MItlsdtor    = 0x10,
+    MIctor       = 0x20,
+    MIdtor       = 0x40,
+    MIxgetMembers = 0x80,
+    MIictor      = 0x100,
+    MIunitTest   = 0x200,
+    MIimportedModules = 0x400,
+    MIlocalClasses = 0x800,
+    MIname       = 0x1000,
+}
+
+
+struct ModuleInfo
+{
+    uint _flags;
+    uint _index; // index into _moduleinfo_array[]
+
+    version (all)
+    {
+        deprecated("ModuleInfo cannot be copy-assigned because it is a variable-sized struct.")
+        void opAssign(in ModuleInfo m) { _flags = m._flags; _index = m._index; }
+    }
+    else
+    {
+        @disable this();
+        @disable this(this) const;
+    }
+
+const:
+    private void* addrOf(int flag) nothrow pure
+    in
+    {
+        assert(flag >= MItlsctor && flag <= MIname);
+        assert(!(flag & (flag - 1)) && !(flag & ~(flag - 1) << 1));
+    }
+    body
+    {
+        void* p = cast(void*)&this + ModuleInfo.sizeof;
+
+        if (flags & MItlsctor)
+        {
+            if (flag == MItlsctor) return p;
+            p += typeof(tlsctor).sizeof;
+        }
+        if (flags & MItlsdtor)
+        {
+            if (flag == MItlsdtor) return p;
+            p += typeof(tlsdtor).sizeof;
+        }
+        if (flags & MIctor)
+        {
+            if (flag == MIctor) return p;
+            p += typeof(ctor).sizeof;
+        }
+        if (flags & MIdtor)
+        {
+            if (flag == MIdtor) return p;
+            p += typeof(dtor).sizeof;
+        }
+        if (flags & MIxgetMembers)
+        {
+            if (flag == MIxgetMembers) return p;
+            p += typeof(xgetMembers).sizeof;
+        }
+        if (flags & MIictor)
+        {
+            if (flag == MIictor) return p;
+            p += typeof(ictor).sizeof;
+        }
+        if (flags & MIunitTest)
+        {
+            if (flag == MIunitTest) return p;
+            p += typeof(unitTest).sizeof;
+        }
+        if (flags & MIimportedModules)
+        {
+            if (flag == MIimportedModules) return p;
+            p += size_t.sizeof + *cast(size_t*)p * typeof(importedModules[0]).sizeof;
+        }
+        if (flags & MIlocalClasses)
+        {
+            if (flag == MIlocalClasses) return p;
+            p += size_t.sizeof + *cast(size_t*)p * typeof(localClasses[0]).sizeof;
+        }
+        if (true || flags & MIname) // always available for now
+        {
+            if (flag == MIname) return p;
+            p += .strlen(cast(immutable char*)p);
+        }
+        assert(0);
+    }
+
+    @property uint index() nothrow pure { return _index; }
+
+    @property uint flags() nothrow pure { return _flags; }
+
+    @property void function() tlsctor() nothrow pure
+    {
+        return flags & MItlsctor ? *cast(typeof(return)*)addrOf(MItlsctor) : null;
+    }
+
+    @property void function() tlsdtor() nothrow pure
+    {
+        return flags & MItlsdtor ? *cast(typeof(return)*)addrOf(MItlsdtor) : null;
+    }
+
+    @property void* xgetMembers() nothrow pure
+    {
+        return flags & MIxgetMembers ? *cast(typeof(return)*)addrOf(MIxgetMembers) : null;
+    }
+
+    @property void function() ctor() nothrow pure
+    {
+        return flags & MIctor ? *cast(typeof(return)*)addrOf(MIctor) : null;
+    }
+
+    @property void function() dtor() nothrow pure
+    {
+        return flags & MIdtor ? *cast(typeof(return)*)addrOf(MIdtor) : null;
+    }
+
+    @property void function() ictor() nothrow pure
+    {
+        return flags & MIictor ? *cast(typeof(return)*)addrOf(MIictor) : null;
+    }
+
+    @property void function() unitTest() nothrow pure
+    {
+        return flags & MIunitTest ? *cast(typeof(return)*)addrOf(MIunitTest) : null;
+    }
+
+    @property immutable(ModuleInfo*)[] importedModules() nothrow pure
+    {
+        if (flags & MIimportedModules)
+        {
+            auto p = cast(size_t*)addrOf(MIimportedModules);
+            return (cast(immutable(ModuleInfo*)*)(p + 1))[0 .. *p];
+        }
+        return null;
+    }
+
+    @property TypeInfo_Class[] localClasses() nothrow pure
+    {
+        if (flags & MIlocalClasses)
+        {
+            auto p = cast(size_t*)addrOf(MIlocalClasses);
+            return (cast(TypeInfo_Class*)(p + 1))[0 .. *p];
+        }
+        return null;
+    }
+
+    @property string name() nothrow pure
+    {
+        if (true || flags & MIname) // always available for now
+        {
+            auto p = cast(immutable char*)addrOf(MIname);
+            return p[0 .. .strlen(p)];
+        }
+        // return null;
+    }
+
+    static int opApply(scope int delegate(ModuleInfo*) dg)
+    {
+        import rt.minfo;
+        // Bugzilla 13084 - enforcing immutable ModuleInfo would break client code
+        return rt.minfo.moduleinfos_apply(
+            (immutable(ModuleInfo*)m) => dg(cast(ModuleInfo*)m));
+    }
+}
+
+unittest
+{
+    ModuleInfo* m1;
+    foreach (m; ModuleInfo)
+    {
+        m1 = m;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Throwable
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -1587,197 +1776,6 @@ unittest
     }
 }
 
-
-///////////////////////////////////////////////////////////////////////////////
-// ModuleInfo
-///////////////////////////////////////////////////////////////////////////////
-
-
-enum
-{
-    MIctorstart  = 0x1,   // we've started constructing it
-    MIctordone   = 0x2,   // finished construction
-    MIstandalone = 0x4,   // module ctor does not depend on other module
-                        // ctors being done first
-    MItlsctor    = 8,
-    MItlsdtor    = 0x10,
-    MIctor       = 0x20,
-    MIdtor       = 0x40,
-    MIxgetMembers = 0x80,
-    MIictor      = 0x100,
-    MIunitTest   = 0x200,
-    MIimportedModules = 0x400,
-    MIlocalClasses = 0x800,
-    MIname       = 0x1000,
-}
-
-
-struct ModuleInfo
-{
-    uint _flags;
-    uint _index; // index into _moduleinfo_array[]
-
-    version (all)
-    {
-        deprecated("ModuleInfo cannot be copy-assigned because it is a variable-sized struct.")
-        void opAssign(in ModuleInfo m) { _flags = m._flags; _index = m._index; }
-    }
-    else
-    {
-        @disable this();
-        @disable this(this) const;
-    }
-
-const:
-    private void* addrOf(int flag) nothrow pure
-    in
-    {
-        assert(flag >= MItlsctor && flag <= MIname);
-        assert(!(flag & (flag - 1)) && !(flag & ~(flag - 1) << 1));
-    }
-    body
-    {
-        void* p = cast(void*)&this + ModuleInfo.sizeof;
-
-        if (flags & MItlsctor)
-        {
-            if (flag == MItlsctor) return p;
-            p += typeof(tlsctor).sizeof;
-        }
-        if (flags & MItlsdtor)
-        {
-            if (flag == MItlsdtor) return p;
-            p += typeof(tlsdtor).sizeof;
-        }
-        if (flags & MIctor)
-        {
-            if (flag == MIctor) return p;
-            p += typeof(ctor).sizeof;
-        }
-        if (flags & MIdtor)
-        {
-            if (flag == MIdtor) return p;
-            p += typeof(dtor).sizeof;
-        }
-        if (flags & MIxgetMembers)
-        {
-            if (flag == MIxgetMembers) return p;
-            p += typeof(xgetMembers).sizeof;
-        }
-        if (flags & MIictor)
-        {
-            if (flag == MIictor) return p;
-            p += typeof(ictor).sizeof;
-        }
-        if (flags & MIunitTest)
-        {
-            if (flag == MIunitTest) return p;
-            p += typeof(unitTest).sizeof;
-        }
-        if (flags & MIimportedModules)
-        {
-            if (flag == MIimportedModules) return p;
-            p += size_t.sizeof + *cast(size_t*)p * typeof(importedModules[0]).sizeof;
-        }
-        if (flags & MIlocalClasses)
-        {
-            if (flag == MIlocalClasses) return p;
-            p += size_t.sizeof + *cast(size_t*)p * typeof(localClasses[0]).sizeof;
-        }
-        if (true || flags & MIname) // always available for now
-        {
-            if (flag == MIname) return p;
-            p += .strlen(cast(immutable char*)p);
-        }
-        assert(0);
-    }
-
-    @property uint index() nothrow pure { return _index; }
-
-    @property uint flags() nothrow pure { return _flags; }
-
-    @property void function() tlsctor() nothrow pure
-    {
-        return flags & MItlsctor ? *cast(typeof(return)*)addrOf(MItlsctor) : null;
-    }
-
-    @property void function() tlsdtor() nothrow pure
-    {
-        return flags & MItlsdtor ? *cast(typeof(return)*)addrOf(MItlsdtor) : null;
-    }
-
-    @property void* xgetMembers() nothrow pure
-    {
-        return flags & MIxgetMembers ? *cast(typeof(return)*)addrOf(MIxgetMembers) : null;
-    }
-
-    @property void function() ctor() nothrow pure
-    {
-        return flags & MIctor ? *cast(typeof(return)*)addrOf(MIctor) : null;
-    }
-
-    @property void function() dtor() nothrow pure
-    {
-        return flags & MIdtor ? *cast(typeof(return)*)addrOf(MIdtor) : null;
-    }
-
-    @property void function() ictor() nothrow pure
-    {
-        return flags & MIictor ? *cast(typeof(return)*)addrOf(MIictor) : null;
-    }
-
-    @property void function() unitTest() nothrow pure
-    {
-        return flags & MIunitTest ? *cast(typeof(return)*)addrOf(MIunitTest) : null;
-    }
-
-    @property immutable(ModuleInfo*)[] importedModules() nothrow pure
-    {
-        if (flags & MIimportedModules)
-        {
-            auto p = cast(size_t*)addrOf(MIimportedModules);
-            return (cast(immutable(ModuleInfo*)*)(p + 1))[0 .. *p];
-        }
-        return null;
-    }
-
-    @property TypeInfo_Class[] localClasses() nothrow pure
-    {
-        if (flags & MIlocalClasses)
-        {
-            auto p = cast(size_t*)addrOf(MIlocalClasses);
-            return (cast(TypeInfo_Class*)(p + 1))[0 .. *p];
-        }
-        return null;
-    }
-
-    @property string name() nothrow pure
-    {
-        if (true || flags & MIname) // always available for now
-        {
-            auto p = cast(immutable char*)addrOf(MIname);
-            return p[0 .. .strlen(p)];
-        }
-        // return null;
-    }
-
-    static int opApply(scope int delegate(ModuleInfo*) dg)
-    {
-        import rt.minfo;
-        // Bugzilla 13084 - enforcing immutable ModuleInfo would break client code
-        return rt.minfo.moduleinfos_apply(
-            (immutable(ModuleInfo*)m) => dg(cast(ModuleInfo*)m));
-    }
-}
-
-unittest
-{
-    ModuleInfo* m1;
-    foreach (m; ModuleInfo)
-    {
-        m1 = m;
-    }
-}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Monitor
@@ -2641,6 +2639,12 @@ version (unittest)
     }
 }
 
+private
+{
+    extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow;
+    extern (C) size_t _d_arraysetcapacity(const TypeInfo ti, size_t newcapacity, void *arrptr) pure nothrow;
+}
+
 /**
  * (Property) Get the current capacity of a slice. The capacity is the size
  * that the slice can grow to before the underlying array must be
@@ -2882,9 +2886,7 @@ template RTInfo(T)
 
 // Helper functions
 
-private:
-
-inout(TypeInfo) getElement(inout TypeInfo value) @trusted pure nothrow
+private inout(TypeInfo) getElement(inout TypeInfo value) @trusted pure nothrow
 {
     TypeInfo element = cast() value;
     for(;;)
@@ -2903,7 +2905,7 @@ inout(TypeInfo) getElement(inout TypeInfo value) @trusted pure nothrow
     return cast(inout) element;
 }
 
-size_t getArrayHash(in TypeInfo element, in void* ptr, in size_t count) @trusted nothrow
+private size_t getArrayHash(in TypeInfo element, in void* ptr, in size_t count) @trusted nothrow
 {
     if(!count)
         return 0;
@@ -2974,8 +2976,6 @@ unittest
     int[S[]] aa = [[S(11)] : 13];
     assert(aa[[S(12)]] == 13); // fails
 }
-
-public:
 
 /// Provide the .dup array property.
 @property auto dup(T)(T[] a)

--- a/src/object_.d
+++ b/src/object_.d
@@ -1287,6 +1287,13 @@ class MemberInfo_field : MemberInfo
 
 class MemberInfo_function : MemberInfo
 {
+    enum
+    {
+        Virtual = 1,
+        Member  = 2,
+        Static  = 4,
+    }
+
     this(string name, TypeInfo ti, void* fp, uint flags)
     {
         m_name = name;
@@ -2857,7 +2864,28 @@ bool _ArrayEq(T1, T2)(T1[] a1, T2[] a2)
     return true;
 }
 
+/**
+Calculates the hash value of $(D arg) with $(D seed) initial value.
+Result may be non-equals with $(D typeid(T).getHash(&arg))
+The $(D seed) value may be used for hash chaining:
+----
+struct Test
+{
+    int a;
+    string b;
+    MyObject c;
 
+    size_t toHash() const @safe pure nothrow
+    {
+        size_t hash = a.hashOf();
+        hash = b.hashOf(hash);
+        size_t h1 = c.myMegaHash();
+        hash = h1.hashOf(hash); //Mix two hash values
+        return hash;
+    }
+}
+----
+*/
 size_t hashOf(T)(auto ref T arg, size_t seed = 0)
 {
     import core.internal.hash;
@@ -2873,6 +2901,9 @@ bool _xopCmp(in void*, in void*)
 {
     throw new Error("TypeInfo.compare is not implemented");
 }
+
+void __ctfeWrite(T...)(auto ref T) {}
+void __ctfeWriteln(T...)(auto ref T values) { __ctfeWrite(values, "\n"); }
 
 /******************************************
  * Create RTInfo for type T

--- a/src/object_.d
+++ b/src/object_.d
@@ -150,16 +150,7 @@ class Object
     }
 }
 
-/************************
- * Returns true if lhs and rhs are equal.
- */
-bool opEquals(const Object lhs, const Object rhs)
-{
-    // A hack for the moment.
-    return opEquals(cast()lhs, cast()rhs);
-}
-
-bool opEquals(Object lhs, Object rhs)
+auto opEquals(Object lhs, Object rhs)
 {
     // If aliased to the same object or both null => equal
     if (lhs is rhs) return true;
@@ -179,6 +170,15 @@ bool opEquals(Object lhs, Object rhs)
 
     // General case => symmetric calls to method opEquals
     return lhs.opEquals(rhs) && rhs.opEquals(lhs);
+}
+
+/************************
+* Returns true if lhs and rhs are equal.
+*/
+auto opEquals(const Object lhs, const Object rhs)
+{
+    // A hack for the moment.
+    return opEquals(cast()lhs, cast()rhs);
 }
 
 /**

--- a/src/object_.d
+++ b/src/object_.d
@@ -1634,51 +1634,6 @@ class Throwable : Object
 }
 
 
-alias Throwable.TraceInfo function(void* ptr) TraceHandler;
-private __gshared TraceHandler traceHandler = null;
-
-
-/**
- * Overrides the default trace hander with a user-supplied version.
- *
- * Params:
- *  h = The new trace handler.  Set to null to use the default handler.
- */
-extern (C) void  rt_setTraceHandler(TraceHandler h)
-{
-    traceHandler = h;
-}
-
-/**
- * Return the current trace handler
- */
-extern (C) TraceHandler rt_getTraceHandler()
-{
-    return traceHandler;
-}
-
-/**
- * This function will be called when an exception is constructed.  The
- * user-supplied trace handler will be called if one has been supplied,
- * otherwise no trace will be generated.
- *
- * Params:
- *  ptr = A pointer to the location from which to generate the trace, or null
- *        if the trace should be generated from within the trace handler
- *        itself.
- *
- * Returns:
- *  An object describing the current calling context or null if no handler is
- *  supplied.
- */
-extern (C) Throwable.TraceInfo _d_traceContext(void* ptr = null)
-{
-    if (traceHandler is null)
-        return null;
-    return traceHandler(ptr);
-}
-
-
 /**
  * The base class of all errors that are safe to catch and handle.
  *

--- a/src/object_.d
+++ b/src/object_.d
@@ -194,13 +194,6 @@ struct Interface
 }
 
 /**
- * Runtime type information about a class. Can be retrieved for any class type
- * or instance by using the .classinfo property.
- * A pointer to this appears as the first entry in the class's vtbl[].
- */
-alias TypeInfo_Class Classinfo;
-
-/**
  * Array of pairs giving the offset and type information for each
  * member in an aggregate.
  */

--- a/src/rt/deh_win32.d
+++ b/src/rt/deh_win32.d
@@ -14,6 +14,7 @@ module rt.deh_win32;
 version (Win32):
 
 import core.sys.windows.windows;
+import rt.monitor_;
 //import core.stdc.stdio;
 
 version (D_InlineAsm_X86)

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -211,6 +211,53 @@ extern (C) int rt_term()
     return 0;
 }
 
+/**********************************************
+ * Trace handler
+ */
+alias Throwable.TraceInfo function(void* ptr) TraceHandler;
+private __gshared TraceHandler traceHandler = null;
+
+
+/**
+ * Overrides the default trace hander with a user-supplied version.
+ *
+ * Params:
+ *  h = The new trace handler.  Set to null to use the default handler.
+ */
+extern (C) void  rt_setTraceHandler(TraceHandler h)
+{
+    traceHandler = h;
+}
+
+/**
+ * Return the current trace handler
+ */
+extern (C) TraceHandler rt_getTraceHandler()
+{
+    return traceHandler;
+}
+
+/**
+ * This function will be called when an exception is constructed.  The
+ * user-supplied trace handler will be called if one has been supplied,
+ * otherwise no trace will be generated.
+ *
+ * Params:
+ *  ptr = A pointer to the location from which to generate the trace, or null
+ *        if the trace should be generated from within the trace handler
+ *        itself.
+ *
+ * Returns:
+ *  An object describing the current calling context or null if no handler is
+ *  supplied.
+ */
+extern (C) Throwable.TraceInfo _d_traceContext(void* ptr = null)
+{
+    if (traceHandler is null)
+        return null;
+    return traceHandler(ptr);
+}
+
 /***********************************
  * Provide out-of-band access to the original C argc/argv
  * passed to this program via main(argc,argv).

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -15,12 +15,188 @@ module rt.monitor_;
 
 //debug=PRINTF;
 
+///////////////////////////////////////////////////////////////////////////////
+// Monitor
+///////////////////////////////////////////////////////////////////////////////
+
+// NOTE: The dtor callback feature is only supported for monitors that are not
+//       supplied by the user.  The assumption is that any object with a user-
+//       supplied monitor may have special storage or lifetime requirements and
+//       that as a result, storing references to local objects within Monitor
+//       may not be safe or desirable.  Thus, devt is only valid if impl is
+//       null.
+
+extern(C) void _d_setSameMutex(shared Object ownee, shared Object owner) nothrow
+in
+{
+    assert(ownee.__monitor is null);
+}
+body
+{
+    auto m = cast(shared(Monitor)*) owner.__monitor;
+
+    if (m is null)
+    {
+        _d_monitor_create(cast(Object) owner);
+        m = cast(shared(Monitor)*) owner.__monitor;
+    }
+
+    auto i = m.impl;
+    if (i is null)
+    {
+        atomicOp!("+=")(m.refs, cast(size_t)1);
+        ownee.__monitor = owner.__monitor;
+        return;
+    }
+    // If m.impl is set (ie. if this is a user-created monitor), assume
+    // the monitor is garbage collected and simply copy the reference.
+    ownee.__monitor = owner.__monitor;
+}
+
+extern (C) void _d_monitordelete(Object h, bool det)
+{
+    // det is true when the object is being destroyed deterministically (ie.
+    // when it is explicitly deleted or is a scope object whose time is up).
+    Monitor* m = getMonitor(h);
+
+    if (m !is null)
+    {
+        IMonitor i = m.impl;
+        if (i is null)
+        {
+            auto s = cast(shared(Monitor)*) m;
+            if(!atomicOp!("-=")(s.refs, cast(size_t) 1))
+            {
+                _d_monitor_devt(m, h);
+                _d_monitor_destroy(h);
+                setMonitor(h, null);
+            }
+            return;
+        }
+        // NOTE: Since a monitor can be shared via setSameMutex it isn't safe
+        //       to explicitly delete user-created monitors--there's no
+        //       refcount and it may have multiple owners.
+        /+
+        if (det && (cast(void*) i) !is (cast(void*) h))
+        {
+            destroy(i);
+            GC.free(cast(void*)i);
+        }
+        +/
+        setMonitor(h, null);
+    }
+}
+
+extern (C) void _d_monitorenter(Object h)
+{
+    Monitor* m = getMonitor(h);
+
+    if (m is null)
+    {
+        _d_monitor_create(h);
+        m = getMonitor(h);
+    }
+
+    IMonitor i = m.impl;
+
+    if (i is null)
+    {
+        _d_monitor_lock(h);
+        return;
+    }
+    i.lock();
+}
+
+extern (C) void _d_monitorexit(Object h)
+{
+    Monitor* m = getMonitor(h);
+    IMonitor i = m.impl;
+
+    if (i is null)
+    {
+        _d_monitor_unlock(h);
+        return;
+    }
+    i.unlock();
+}
+
+extern (C) void _d_monitor_devt(Monitor* m, Object h)
+{
+    if (m.devt.length)
+    {
+        DEvent[] devt;
+
+        synchronized (h)
+        {
+            devt = m.devt;
+            m.devt = null;
+        }
+        foreach (v; devt)
+        {
+            if (v)
+                v(h);
+        }
+        free(devt.ptr);
+    }
+}
+
+extern (C) void rt_attachDisposeEvent(Object h, DEvent e)
+{
+    synchronized (h)
+    {
+        Monitor* m = getMonitor(h);
+        assert(m.impl is null);
+
+        foreach (ref v; m.devt)
+        {
+            if (v is null || v == e)
+            {
+                v = e;
+                return;
+            }
+        }
+
+        auto len = m.devt.length + 4; // grow by 4 elements
+        auto pos = m.devt.length;     // insert position
+        auto p = realloc(m.devt.ptr, DEvent.sizeof * len);
+        import core.exception : onOutOfMemoryError;
+        if (!p)
+            onOutOfMemoryError();
+        m.devt = (cast(DEvent*)p)[0 .. len];
+        m.devt[pos+1 .. len] = null;
+        m.devt[pos] = e;
+    }
+}
+
+extern (C) void rt_detachDisposeEvent(Object h, DEvent e)
+{
+    synchronized (h)
+    {
+        Monitor* m = getMonitor(h);
+        assert(m.impl is null);
+
+        foreach (p, v; m.devt)
+        {
+            if (v == e)
+            {
+                memmove(&m.devt[p],
+                        &m.devt[p+1],
+                        (m.devt.length - p - 1) * DEvent.sizeof);
+                m.devt[$ - 1] = null;
+                return;
+            }
+        }
+    }
+}
+
 nothrow:
 
 private
 {
     debug(PRINTF) import core.stdc.stdio;
     import core.stdc.stdlib;
+    import core.stdc.string;
+    import core.atomic;
 
     version( linux )
     {

--- a/src/rt/util/string.d
+++ b/src/rt/util/string.d
@@ -27,21 +27,19 @@ version(D_LP64)
 else
     alias SizeStringBuff = UintStringBuff;
 
-char[] uintToTempString(size_t n)(in uint val, ref char[n] buff)
+char[] uintToTempString(in uint val, char[] buff)
 { return val._unsignedToTempString(buff); }
 
-char[] ulongToTempString(size_t n)(in ulong val, ref char[n] buff)
+char[] ulongToTempString(in ulong val, char[] buff)
 { return val._unsignedToTempString(buff); }
 
-version(D_LP64)
-    alias sizeToTempString = ulongToTempString;
-else
-    alias sizeToTempString = uintToTempString;
+char[] sizeToTempString(in size_t val, char[] buff)
+{ return val._unsignedToTempString(buff); }
 
-private char[] _unsignedToTempString(T, size_t n)(in T val, ref char[n] buff)
+private char[] _unsignedToTempString(T)(in T val, char[] buff)
 if(is(T == uint) || is(T == ulong))
 {
-    static assert(n >= (is(T == uint) ? 10 : 20), "Buffer is to small for `" ~ T.stringof ~ "`.");
+    assert(buff.length >= (is(T == uint) ? 10 : 20), "Buffer is too small for `" ~ T.stringof ~ "`.");
 
     char* p = buff.ptr + buff.length;
     T k = val;

--- a/win32.mak
+++ b/win32.mak
@@ -207,7 +207,7 @@ copydir: $(IMPDIR)
 
 copy: $(COPY)
 
-$(IMPDIR)\object.di : src\object.di
+$(IMPDIR)\object.di : src\object_.d
 	copy $** $@
 
 $(IMPDIR)\core\atomic.d : src\core\atomic.d

--- a/win64.mak
+++ b/win64.mak
@@ -217,7 +217,7 @@ copydir: $(IMPDIR)
 
 copy: $(COPY)
 
-$(IMPDIR)\object.di : src\object.di
+$(IMPDIR)\object.di : src\object_.d
 	copy $** $@
 
 $(IMPDIR)\core\atomic.d : src\core\atomic.d


### PR DESCRIPTION
Updating object.di and object_.d is a maintenance liability. This PR removes non-public code from object._d and adds a bit from object.di in order to generate the latter automatically.

Comparing object.di to the generated header reveals:
- aliases for string,wstring,dstring not converted correctly, needs https://github.com/D-Programming-Language/dmd/pull/4594
- overriding methods often not declared in classes declared in object.di. This can cause unexpected results when deriving from this class and calling `super.method()`.
- different types for `TpeInfo_Class.defaultConstructor`
- different return types for `TypeInfo_Struct.xtoHash`
- missing fields in classes `MemberInfo_field` and `MemberInfo_function`, can have bad effects when deriving from it or using `__traits(classInstanceSize)`.
- different next/base field declarations for `TypeInfo_Const`. See also https://github.com/D-Programming-Language/druntime/pull/1182
- header generation moves function attributes before the return type.

Unfortunately, neither the generated object_.di nor the original object_.d can be used as a replacement for object.di yet:
- object_.d does not work because it has (now local) imports to the rt package which are not supposed to be visible in general.
- object_.di does not contain all the source code necessary for CTFE. Adding `auto` can work in some places, but not for the `Exception` and `Error` constructors.
- in addition, the missing source in object_.di can disable some inlining opportunities, especially for the AA templates.

So we need better control over the omission of the code in the generated headers. Adding inline hints might be a possible solution, though somewhat abusive in the case of CTFE.