### PR TITLE
Mark exception class constructors as @nogc

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -357,8 +357,8 @@ class Throwable : Object
     TraceInfo   info;
     Throwable   next;
 
-    @safe pure nothrow this(string msg, Throwable next = null);
-    @safe pure nothrow this(string msg, string file, size_t line, Throwable next = null);
+    @nogc @safe pure nothrow this(string msg, Throwable next = null);
+    @nogc @safe pure nothrow this(string msg, string file, size_t line, Throwable next = null);
     override string toString();
     void toString(scope void delegate(in char[]) sink) const;
 }
@@ -366,12 +366,12 @@ class Throwable : Object
 
 class Exception : Throwable
 {
-    @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+    @nogc @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
     {
         super(msg, file, line, next);
     }
 
-    @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
+    @nogc @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
     {
         super(msg, file, line, next);
     }
@@ -380,13 +380,13 @@ class Exception : Throwable
 
 class Error : Throwable
 {
-    @safe pure nothrow this(string msg, Throwable next = null)
+    @nogc @safe pure nothrow this(string msg, Throwable next = null)
     {
         super(msg, next);
         bypassedException = null;
     }
 
-    @safe pure nothrow this(string msg, string file, size_t line, Throwable next = null)
+    @nogc @safe pure nothrow this(string msg, string file, size_t line, Throwable next = null)
     {
         super(msg, file, line, next);
         bypassedException = null;

--- a/src/object_.d
+++ b/src/object_.d
@@ -1365,14 +1365,14 @@ class Throwable : Object
      */
     Throwable   next;
 
-    @safe pure nothrow this(string msg, Throwable next = null)
+    @nogc @safe pure nothrow this(string msg, Throwable next = null)
     {
         this.msg = msg;
         this.next = next;
         //this.info = _d_traceContext();
     }
 
-    @safe pure nothrow this(string msg, string file, size_t line, Throwable next = null)
+    @nogc @safe pure nothrow this(string msg, string file, size_t line, Throwable next = null)
     {
         this(msg, next);
         this.file = file;
@@ -1491,12 +1491,12 @@ class Exception : Throwable
      * This constructor does not automatically throw the newly-created
      * Exception; the $(D throw) statement should be used for that purpose.
      */
-    @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+    @nogc @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
     {
         super(msg, file, line, next);
     }
 
-    @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
+    @nogc @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
     {
         super(msg, file, line, next);
     }
@@ -1547,13 +1547,13 @@ class Error : Throwable
      * This constructor does not automatically throw the newly-created
      * Error; the $(D throw) statement should be used for that purpose.
      */
-    @safe pure nothrow this(string msg, Throwable next = null)
+    @nogc @safe pure nothrow this(string msg, Throwable next = null)
     {
         super(msg, next);
         bypassedException = null;
     }
 
-    @safe pure nothrow this(string msg, string file, size_t line, Throwable next = null)
+    @nogc @safe pure nothrow this(string msg, string file, size_t line, Throwable next = null)
     {
         super(msg, file, line, next);
         bypassedException = null;


### PR DESCRIPTION
The exception class constructors do not themselves allocate any memory in the garbage collector, so they can be marked as @nogc. This enables the exception constructors to be used with custom allocators in the future in @nogc code.

I admit that this change was so trivial I just did it directly through GitHub.