### PR TITLE
Fix issue 14467 - arr.capacity sometimes erroneously returns 0

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -3155,6 +3155,7 @@ struct SmallObjectPool
 
         info.base = cast(void*)((cast(size_t)p) & notbinsize[bin]);
         info.size = binsize[bin];
+        offset = info.base - baseAddr;
         info.attr = getBits(cast(size_t)(offset >> shiftBy));
 
         return info;
@@ -3240,6 +3241,14 @@ struct SmallObjectPool
         (cast(List *)p).pool = &base;
         return first;
     }
+}
+
+unittest // bugzilla 14467
+{
+    int[] arr = new int[10];
+    assert(arr.capacity);
+    arr = arr[$..$];
+    assert(arr.capacity);
 }
 
 /* ============================ SENTINEL =============================== */


### PR DESCRIPTION
(Note, reopened from https://github.com/D-Programming-Language/druntime/pull/1226)

In small object pool, the bits retrieved when using `Pool.getInfo` should be for the block, not the specific pointer. This was changed in https://github.com/D-Programming-Language/druntime/pull/1127 accidentally, I believe. This PR restores the original meaning.

Also, I noticed there is no other unit tests in this file. I don't know if I put the unit test in the right place.

Bugzilla: https://issues.dlang.org/show_bug.cgi?id=14467