### PR TITLE
Remove _d_hidden_func and deprecate helper class and function

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -183,8 +183,10 @@ unittest
 
 /**
  * Thrown on hidden function error.
+ * $(RED Deprecated.
+ *   This feature is not longer part of the language.
  */
-class HiddenFuncError : Error
+deprecated class HiddenFuncError : Error
 {
     @safe pure nothrow this( ClassInfo ci )
     {
@@ -496,11 +498,13 @@ extern (C) void onFinalizeError( TypeInfo info, Throwable e, string file = __FIL
 /**
  * A callback for hidden function errors in D.  A $(LREF HiddenFuncError) will be
  * thrown.
+ * $(RED Deprecated.
+ *   This feature is not longer part of the language.
  *
  * Throws:
  *  $(LREF HiddenFuncError).
  */
-extern (C) void onHiddenFuncError( Object o ) @safe pure nothrow
+deprecated extern (C) void onHiddenFuncError( Object o ) @safe pure nothrow
 {
     throw new HiddenFuncError( typeid(o) );
 }
@@ -643,24 +647,5 @@ extern (C)
     void _d_switch_error(immutable(ModuleInfo)* m, uint line)
     {
         onSwitchError(m.name, line);
-    }
-
-    void _d_hidden_func()
-    {
-        Object o;
-        version(D_InlineAsm_X86)
-            asm
-            {
-                mov o, EAX;
-            }
-        else version(D_InlineAsm_X86_64)
-            asm
-            {
-                mov o, RDI;
-            }
-        else
-            static assert(0, "unknown os");
-
-        onHiddenFuncError(o);
     }
 }


### PR DESCRIPTION
https://github.com/D-Programming-Language/dmd/pull/4606

I assume it is proper for first deprecating ``HiddenFuncError`` and ``onHiddenFuncError`` just incase there's any client-side usage of these.