### PR TITLE
Fix 14215 - Unnecessary imports of core.stdc.stddef for size_t and ptrdiff_t

### DIFF
--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -14,7 +14,7 @@
 
 module core.stdc.stdint;
 
-private import core.stdc.stddef; // for ptrdiff_t, size_t, wchar_t
+private import core.stdc.stddef; // for wchar_t
 private import core.stdc.signal; // for sig_atomic_t
 private import core.stdc.wchar_; // for wint_t
 

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -18,7 +18,6 @@ module core.stdc.stdio;
 private
 {
     import core.stdc.config;
-    import core.stdc.stddef; // for size_t
     import core.stdc.stdarg; // for va_list
     import core.stdc.stdint : intptr_t;
 

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -15,7 +15,7 @@
 module core.stdc.stdlib;
 
 private import core.stdc.config;
-public import core.stdc.stddef; // for size_t, wchar_t
+public import core.stdc.stddef; // for wchar_t
 
 extern (C):
 @system:

--- a/src/core/stdc/string.d
+++ b/src/core/stdc/string.d
@@ -14,8 +14,6 @@
 
 module core.stdc.string;
 
-private import core.stdc.stddef; // for size_t
-
 extern (C):
 @system:
 nothrow:

--- a/src/core/stdc/time.d
+++ b/src/core/stdc/time.d
@@ -16,7 +16,6 @@
 module core.stdc.time;
 
 private import core.stdc.config;
-private import core.stdc.stddef; // for size_t
 
 extern (C):
 @trusted: // There are only a few functions here that use unsafe C strings.

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -17,7 +17,7 @@ module core.stdc.wchar_;
 private import core.stdc.config;
 private import core.stdc.stdarg; // for va_list
 private import core.stdc.stdio;  // for FILE, not exposed per spec
-public import core.stdc.stddef;  // for size_t, wchar_t
+public import core.stdc.stddef;  // for wchar_t
 public import core.stdc.time;    // for tm
 public import core.stdc.stdint;  // for WCHAR_MIN, WCHAR_MAX
 

--- a/src/core/sys/linux/stdio.d
+++ b/src/core/sys/linux/stdio.d
@@ -11,7 +11,7 @@ public import core.sys.posix.stdio;
 import core.sys.posix.sys.types : ssize_t, off64_t = off_t;
 import core.sys.linux.config : __USE_FILE_OFFSET64;
 import core.stdc.stdio : FILE;
-import core.stdc.stddef : wchar_t, size_t;
+import core.stdc.stddef : wchar_t;
 
 extern(C) nothrow
 {

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -16,7 +16,6 @@ module core.sys.posix.fcntl;
 
 private import core.sys.posix.config;
 private import core.stdc.stdint;
-public import core.stdc.stddef;         // for size_t
 public import core.sys.posix.sys.types; // for off_t, mode_t
 public import core.sys.posix.sys.stat;  // for S_IFMT, etc.
 

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -13,7 +13,6 @@ module core.sys.posix.signal;
 
 private import core.sys.posix.config;
 public import core.stdc.signal;
-public import core.stdc.stddef;         // for size_t
 public import core.sys.posix.sys.types; // for pid_t
 //public import core.sys.posix.time;      // for timespec, now defined here
 

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -15,7 +15,6 @@
 module core.sys.posix.sys.mman;
 
 private import core.sys.posix.config;
-public import core.stdc.stddef;          // for size_t
 public import core.sys.posix.sys.types; // for off_t, mode_t
 
 version (Posix):

--- a/src/core/sys/posix/sys/shm.d
+++ b/src/core/sys/posix/sys/shm.d
@@ -15,7 +15,7 @@
 module core.sys.posix.sys.shm;
 
 private import core.sys.posix.config;
-public import core.sys.posix.sys.types; // for pid_t, time_t, key_t, size_t
+public import core.sys.posix.sys.types; // for pid_t, time_t, key_t
 public import core.sys.posix.sys.ipc;
 
 version (Posix):

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -15,7 +15,7 @@
 module core.sys.posix.sys.socket;
 
 private import core.sys.posix.config;
-public import core.sys.posix.sys.types; // for ssize_t, size_t
+public import core.sys.posix.sys.types; // for ssize_t
 public import core.sys.posix.sys.uio;   // for iovec
 
 version (Posix):

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -17,7 +17,6 @@ module core.sys.posix.sys.stat;
 private import core.sys.posix.config;
 private import core.stdc.stdint;
 private import core.sys.posix.time;     // for timespec
-public import core.stdc.stddef;          // for size_t
 public import core.sys.posix.sys.types; // for off_t, mode_t
 
 version (Posix):

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -17,7 +17,7 @@ module core.sys.posix.sys.types;
 
 private import core.sys.posix.config;
 private import core.stdc.stdint;
-public import core.stdc.stddef; // for size_t
+public import core.stdc.stddef;
 
 version (Posix):
 extern (C):

--- a/src/core/sys/posix/sys/uio.d
+++ b/src/core/sys/posix/sys/uio.d
@@ -15,7 +15,7 @@
 module core.sys.posix.sys.uio;
 
 private import core.sys.posix.config;
-public import core.sys.posix.sys.types; // for ssize_t, size_t
+public import core.sys.posix.sys.types; // for ssize_t
 
 version (Posix):
 extern (C) nothrow @nogc:

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -17,7 +17,7 @@ module core.sys.posix.unistd;
 private import core.sys.posix.config;
 private import core.stdc.stddef;
 public import core.sys.posix.inttypes;  // for intptr_t
-public import core.sys.posix.sys.types; // for size_t, ssize_t, uid_t, gid_t, off_t, pid_t, useconds_t
+public import core.sys.posix.sys.types; // for ssize_t, uid_t, gid_t, off_t, pid_t, useconds_t
 
 version (Posix):
 extern (C):


### PR DESCRIPTION
[Ketmar is right](https://issues.dlang.org/show_bug.cgi?id=14215), `size_t` and `ptrdiff_t` were moved to `object.di` at least five years ago, so all these imports and references to them are wrong.  The four deleted public imports might still be inadvertently used to import the remaining `wchar_t` alias, but since that only seems likely for `core.sys.posix.sys.types`, I only left that one public import in.