### PR TITLE
Fix Issue 12289 - incorrect core.stdc.stdio.fpos_t alias and mbstate_t for glibc

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -25,10 +25,6 @@ private
   {
     import core.sys.posix.sys.types;
   }
-  else version (Android)
-  {
-    import core.sys.posix.sys.types: off_t;
-  }
 }
 
 extern (C):
@@ -237,7 +233,7 @@ enum
 version( CRuntime_DigitalMars )
 {
     ///
-    alias int fpos_t; //check this
+    alias c_long fpos_t;
 
     ///
     struct _iobuf
@@ -258,7 +254,7 @@ version( CRuntime_DigitalMars )
 else version( CRuntime_Microsoft )
 {
     ///
-    alias int fpos_t; //check this
+    alias long fpos_t;
 
     ///
     struct _iobuf
@@ -278,8 +274,13 @@ else version( CRuntime_Microsoft )
 }
 else version( linux )
 {
+    import core.stdc.wchar_ : mbstate_t;
     ///
-    alias int fpos_t; //this is probably wrong, fix this
+    struct fpos_t
+    {
+        long __pos; // couldn't use off_t because of static if issue
+        mbstate_t __state;
+    }
 
     ///
     struct _IO_FILE
@@ -308,14 +309,14 @@ else version( linux )
     }
 
     ///
-    alias _IO_FILE _iobuf; //remove later
+    alias _IO_FILE _iobuf;
     ///
     alias shared(_IO_FILE) FILE;
 }
 else version( OSX )
 {
     ///
-    alias int fpos_t; //check this
+    alias long fpos_t;
 
     ///
     struct __sFILE
@@ -348,14 +349,14 @@ else version( OSX )
     }
 
     ///
-    alias __sFILE _iobuf; //remove later
+    alias __sFILE _iobuf;
     ///
     alias shared(__sFILE) FILE;
 }
 else version( FreeBSD )
 {
     ///
-    alias int fpos_t; //check this
+    alias off_t fpos_t;
 
     ///
     struct __sFILE
@@ -394,14 +395,14 @@ else version( FreeBSD )
     }
 
     ///
-    alias __sFILE _iobuf; //remove later
+    alias __sFILE _iobuf;
     ///
     alias shared(__sFILE) FILE;
 }
 else version (Solaris)
 {
     ///
-    alias int fpos_t; //check this
+    alias c_long fpos_t;
 
     ///
     struct _iobuf
@@ -424,6 +425,7 @@ else version (Solaris)
 }
 else version( Android )
 {
+    import core.sys.posix.sys.types : off_t;
     ///
     alias off_t fpos_t;
 
@@ -458,7 +460,7 @@ else version( Android )
     }
 
     ///
-    alias __sFILE _iobuf; //remove later
+    alias __sFILE _iobuf;
     ///
     alias shared(__sFILE) FILE;
 }

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -26,8 +26,26 @@ extern (C):
 nothrow:
 @nogc:
 
-///
-alias int     mbstate_t;
+version( CRuntime_Glibc )
+{
+    ///
+    struct mbstate_t
+    {
+        int __count;
+        union ___value
+        {
+            wint_t __wch;
+            char[4] __wchb;
+        }
+        ___value __value;
+    }
+}
+else
+{
+    ///
+    alias int mbstate_t;
+}
+
 ///
 alias wchar_t wint_t;
 


### PR DESCRIPTION
I noticed `fpos_t` was defined wrongly in `core.stdc.stdio` a while back, finally fixing it.  I couldn't find where [`__darwin_off_t` was defined in Apple's libc headers for `OSX`](http://www.opensource.apple.com/source/Libc/Libc-1044.1.2/include/stdio.h), probably because the definition is automatically generated, so @jacob-carlborg or someone else will have to fill me in on that one.  [I read the headers for Solaris](http://src.illumos.org/source/xref/illumos-gate/usr/src/ucbhead/stdio.h#78), @redstar can tell me if I got it wrong.  The others were checked with a test C file run through the native preprocessor, so they should be okay.

I had to fix `mbstate_t` for glibc, didn't bother checking that one on the other OS's.  I also deleted the comments about removing the shared file handle `_iobuf` eventually, as it's used more than I thought in `std.stdio`.