### PR TITLE
check whether TLS is ready to be used in the profiler

### DIFF
--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -585,7 +585,8 @@ private void trace_pro(char[] id)
 {
     //printf("trace_pro(ptr = %p, length = %lld)\n", id.ptr, id.length);
     //printf("trace_pro(id = '%.*s')\n", id.length, id.ptr);
-
+    if (!tlsReady)
+        return;
     if (!trace_inited)
     {
         trace_inited = true;
@@ -629,6 +630,8 @@ void _c_trace_pro(size_t idlen, char* idptr)
 void _c_trace_epi()
 {
     //printf("_c_trace_epi()\n");
+    if (!tlsReady)
+        return;
     auto tos = trace_tos;
     if (tos)
     {
@@ -811,6 +814,24 @@ private void trace_merge(Symbol** proot)
         }
     L1:
         fclose(fp);
+    }
+}
+
+////////////////////////// TLS /////////////////////
+
+/// true when (emulated) TLS can be used
+@property bool tlsReady()
+{
+    version (OSX)
+    {
+        // don't profile until TLS is initialized
+        import rt.sections : _isRuntimeInitialized;
+        if (!_isRuntimeInitialized)
+            return;
+    }
+    else
+    {
+        return true;
     }
 }
 


### PR DESCRIPTION
- the emulated TLS on OSX is initialized by druntime,
  so we can't profile until that is done