### PR TITLE
Simplify the check if cent/ucent is supported.

### DIFF
--- a/src/rt/typeinfo/ti_cent.d
+++ b/src/rt/typeinfo/ti_cent.d
@@ -15,7 +15,7 @@ module rt.typeinfo.ti_cent;
 
 private import rt.util.hash;
 
-static if(__traits(compiles, { cent c = 42; })):
+static if(is(cent)):
 
 // cent
 

--- a/src/rt/typeinfo/ti_ucent.d
+++ b/src/rt/typeinfo/ti_ucent.d
@@ -15,7 +15,7 @@ module rt.typeinfo.ti_ucent;
 
 private import rt.util.hash;
 
-static if (__traits(compiles, { ucent uc = 42; })):
+static if (is(ucent)):
 
 // ucent
 


### PR DESCRIPTION
The same check is used in Phobos in module std.traits.