### PR TITLE
fix Issue 14476 - core.thread unit tests failing on FreeBSD 9+

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -5214,6 +5214,7 @@ version (FreeBSD) unittest
 
 unittest
 {
-    auto thr = new Thread(function{}, 10).start();
+    // use >PAGESIZE to avoid stack overflow (e.g. in an syscall)
+    auto thr = new Thread(function{}, 4096 + 1).start();
     thr.join();
 }


### PR DESCRIPTION
- the newly created thread fails because of a stack overflow
  in a syscall to sbrk triggered by pthread_attr_get_np/calloc

- [Issue 14476 – core.thread unit tests failing on FreeBSD 9+](https://issues.dlang.org/show_bug.cgi?id=14476)