### PR TITLE
Fix bug# 14546 - Make the druntime documentation buildable again.

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2648,7 +2648,14 @@ private immutable long[__traits(allMembers, ClockType).length] _ticksPerSecond;
 
 @trusted shared static this()
 {
-    version(Windows)
+    // If we try to do anything with ClockType in the documentation build, it'll
+    // trigger the static assertions related to ClockType, since the
+    // documentation build defines all of the possible ClockTypes, which won't
+    // work when they're used in the static ifs, because no system supports them
+    // all.
+    version(CoreDdoc)
+    {}
+    else version(Windows)
     {
         long ticksPerSecond;
         if(QueryPerformanceFrequency(&ticksPerSecond) != 0)


### PR DESCRIPTION
This makes it so that ClockType isn't actually used in core.time in the
documentation build (since if it is, it triggers static assertions,
since none of the systems support all of the ClockTypes, but they all
have to be defined for the documentation build in order to show up in
the docs).