### PR TITLE
Also fix complex template test in core.demangle

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1943,7 +1943,7 @@ version(unittest)
         ["_D8demangle29__T2fnVa97Va9Va0Vu257Vw65537Z2fnFZv", "void demangle.fn!('a', '\\t', \\x00, '\\u0101', '\\U00010001').fn()"],
         ["_D2gc11gctemplates56__T8mkBitmapTS3std5range13__T4iotaTiTiZ4iotaFiiZ6ResultZ8mkBitmapFNbNiNfPmmZv",
          "nothrow @nogc @safe void gc.gctemplates.mkBitmap!(std.range.iota!(int, int).iota(int, int).Result).mkBitmap(ulong*, ulong)"],
-        ["_D8serenity9persister6Sqlite70__T15SqlitePersisterTS8serenity9persister6Sqlite11__unittest6FZv4TestZ15SqlitePersister12__T7opIndexZ7opIndexMFmZS8serenity9persister6Sqlite11__unittest6FZv4Test",
+        ["_D8serenity9persister6Sqlite69__T15SqlitePersisterTS8serenity9persister6Sqlite11__unittest6FZ4TestZ15SqlitePersister12__T7opIndexZ7opIndexMFmZS8serenity9persister6Sqlite11__unittest6FZ4Test",
          "serenity.persister.Sqlite.__unittest6().Test serenity.persister.Sqlite.SqlitePersister!(serenity.persister.Sqlite.__unittest6().Test).SqlitePersister.opIndex!().opIndex(ulong)"],
         ["_D8bug100274mainFZ5localMFZi","int bug10027.main().local()"],
         ["_D8demangle4testFNhG16gZv", "void demangle.test(__vector(byte[16]))"],


### PR DESCRIPTION
Follow up to #1263 

@MartinNowak - this adjustment I've made is by assuming that the ABI is followed precisely.

I have yet to get the serenity library and rebuild it to check whether the ABI mangling reported in 2011 is still the same as today.