### PR TITLE
skip null classinfo

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -879,6 +879,7 @@ class TypeInfo_Class : TypeInfo
             //writefln("module %s, %d", m.name, m.localClasses.length);
             foreach (c; m.localClasses)
             {
+                if (c is null) continue;
                 //writefln("\tclass %s", c.name);
                 if (c.name == classname)
                     return c;


### PR DESCRIPTION
- needed to weakly link against classinfo (Isssue 14555)

[Issue 14555 – ModuleInfo should weakly link against classes](https://issues.dlang.org/show_bug.cgi?id=14555)
https://github.com/D-Programming-Language/dmd/pull/4638