### PR TITLE
Add Android/ARM support

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -192,6 +192,11 @@ else version( Android )
 
         alias ushort fexcept_t;
     }
+    else version(ARM)
+    {
+        alias uint fenv_t;
+        alias uint fexcept_t;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -185,20 +185,13 @@ else version( Android )
         DT_WHT      = 14
     }
 
-    version (X86)
+    struct dirent
     {
-        struct dirent
-        {
-            ulong       d_ino;
-            long        d_off;
-            ushort      d_reclen;
-            ubyte       d_type;
-            char[256]   d_name;
-        }
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
+        ulong       d_ino;
+        long        d_off;
+        ushort      d_reclen;
+        ubyte       d_type;
+        char[256]   d_name;
     }
 
     struct DIR

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -495,6 +495,17 @@ else version( Android )
         enum O_NONBLOCK     = 0x800;    // octal    04000
         enum O_SYNC         = 0x1000;   // octal   010000
     }
+    else version (ARM)
+    {
+        enum O_CREAT        = 0x40;     // octal     0100
+        enum O_EXCL         = 0x80;     // octal     0200
+        enum O_NOCTTY       = 0x100;    // octal     0400
+        enum O_TRUNC        = 0x200;    // octal    01000
+
+        enum O_APPEND       = 0x400;    // octal    02000
+        enum O_NONBLOCK     = 0x800;    // octal    04000
+        enum O_SYNC         = 0x1000;   // octal   010000
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -168,6 +168,10 @@ else version( Android )
     {
         enum _JBLEN = 10;
     }
+    else version( ARM )
+    {
+        enum _JBLEN = 64;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -470,6 +470,21 @@ else version (Android)
             void function() sa_restorer;
         }
     }
+    else version (ARM)
+    {
+        struct sigaction_t
+        {
+            union
+            {
+                sigfn_t    sa_handler;
+                sigactfn_t sa_sigaction;
+            }
+
+            sigset_t        sa_mask;
+            c_ulong         sa_flags;
+            void function() sa_restorer;
+        }
+    }
     else
     {
         static assert(false, "Architecture not supported.");
@@ -941,6 +956,11 @@ else version( Android )
     private import core.stdc.string : memset;
 
     version (X86)
+    {
+        alias c_ulong sigset_t;
+        enum int LONG_BIT = 32;
+    }
+    else version (ARM)
     {
         alias c_ulong sigset_t;
         enum int LONG_BIT = 32;
@@ -1709,6 +1729,34 @@ else version (Solaris)
 else version (Android)
 {
     version (X86)
+    {
+        enum SIGPOLL   = 29;
+        enum SIGPROF   = 27;
+        enum SIGSYS    = 31;
+        enum SIGTRAP   = 5;
+        enum SIGVTALRM = 26;
+        enum SIGXCPU   = 24;
+        enum SIGXFSZ   = 25;
+
+        enum SA_ONSTACK     = 0x08000000;
+        enum SA_RESETHAND   = 0x80000000;
+        enum SA_RESTART     = 0x10000000;
+        enum SA_SIGINFO     = 4;
+        enum SA_NOCLDWAIT   = 2;
+        enum SA_NODEFER     = 0x40000000;
+        enum SS_ONSTACK     = 1;
+        enum SS_DISABLE     = 2;
+        enum MINSIGSTKSZ    = 2048;
+        enum SIGSTKSZ       = 8192;
+
+        struct stack_t
+        {
+            void*   ss_sp;
+            int     ss_flags;
+            size_t  ss_size;
+        }
+    }
+    else version (ARM)
     {
         enum SIGPOLL   = 29;
         enum SIGPROF   = 27;

--- a/src/core/sys/posix/sys/ipc.d
+++ b/src/core/sys/posix/sys/ipc.d
@@ -130,6 +130,19 @@ else version( Android )
             ushort  seq;
         }
     }
+    else version (ARM)
+    {
+        struct ipc_perm
+        {
+            key_t   key;
+            ushort  uid;
+            ushort  gid;
+            ushort  cuid;
+            ushort  cgid;
+            mode_t  mode;
+            ushort  seq;
+        }
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -343,6 +343,10 @@ else version (Android)
     {
         enum MAP_ANON       = 0x0020;
     }
+    else version (ARM)
+    {
+        enum MAP_ANON       = 0x0020;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -1095,25 +1095,63 @@ else version( Android )
         int l_linger;
     }
 
+    struct msghdr
+    {
+        void*           msg_name;
+        int             msg_namelen;
+        iovec*          msg_iov;
+        __kernel_size_t msg_iovlen;
+        void*           msg_control;
+        __kernel_size_t msg_controllen;
+        uint            msg_flags;
+    }
+
+    struct cmsghdr
+    {
+        __kernel_size_t cmsg_len;
+        int             cmsg_level;
+        int             cmsg_type;
+    }
+
     version (X86)
     {
-        struct msghdr
+        alias uint __kernel_size_t;
+
+        enum
         {
-            void*  msg_name;
-            int    msg_namelen;
-            iovec* msg_iov;
-            uint   msg_iovlen;
-            void*  msg_control;
-            uint   msg_controllen;
-            uint   msg_flags;
+            SOCK_DGRAM      = 2,
+            SOCK_SEQPACKET  = 5,
+            SOCK_STREAM     = 1
         }
 
-        struct cmsghdr
+        enum
         {
-            uint cmsg_len;
-            int  cmsg_level;
-            int  cmsg_type;
+            SOL_SOCKET      = 1
         }
+
+        enum
+        {
+            SO_ACCEPTCONN   = 30,
+            SO_BROADCAST    = 6,
+            SO_DEBUG        = 1,
+            SO_DONTROUTE    = 5,
+            SO_ERROR        = 4,
+            SO_KEEPALIVE    = 9,
+            SO_LINGER       = 13,
+            SO_OOBINLINE    = 10,
+            SO_RCVBUF       = 8,
+            SO_RCVLOWAT     = 18,
+            SO_RCVTIMEO     = 20,
+            SO_REUSEADDR    = 2,
+            SO_SNDBUF       = 7,
+            SO_SNDLOWAT     = 19,
+            SO_SNDTIMEO     = 21,
+            SO_TYPE         = 3
+        }
+    }
+    else version (ARM)
+    {
+        alias uint __kernel_size_t;
 
         enum
         {

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -897,6 +897,32 @@ else version( Android )
             ulong       st_ino;
         }
     }
+    else version (ARM)
+    {
+        struct stat_t
+        {
+            ulong       st_dev;
+            ubyte[4]    __pad0;
+            c_ulong     __st_ino;
+            uint        st_mode;
+            uint        st_nlink;
+            c_ulong     st_uid;
+            c_ulong     st_gid;
+            ulong       st_rdev;
+            ubyte[4]    __pad3;
+
+            long        st_size;
+            c_ulong     st_blksize;
+            ulong       st_blocks;
+            c_ulong     st_atime;
+            c_ulong     st_atime_nsec;
+            c_ulong     st_mtime;
+            c_ulong     st_mtime_nsec;
+            c_ulong     st_ctime;
+            c_ulong     st_ctime_nsec;
+            ulong       st_ino;
+        }
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -182,20 +182,31 @@ else version (Solaris)
 }
 else version( Android )
 {
+    alias c_ulong   blkcnt_t;
+    alias c_ulong   blksize_t;
+    alias uint      dev_t;
+    alias uint      gid_t;
+    alias c_ulong   ino_t;
+    alias c_long    off_t;
+    alias int       pid_t;
+    alias int       ssize_t;
+    alias c_long    time_t;
+    alias uint      uid_t;
+
     version(X86)
     {
-        alias c_ulong   blkcnt_t;
-        alias c_ulong   blksize_t;
-        alias uint      dev_t;
-        alias uint      gid_t;
-        alias c_ulong   ino_t;
         alias ushort    mode_t;
         alias ushort    nlink_t;
-        alias c_long    off_t;
-        alias int       pid_t;
-        alias c_long    ssize_t;
-        alias c_long    time_t;
-        alias uint      uid_t;
+    }
+    else version(ARM)
+    {
+        alias ushort    mode_t;
+        alias ushort    nlink_t;
+    }
+    else version(MIPS32)
+    {
+        alias uint      mode_t;
+        alias uint      nlink_t;
     }
     else
     {
@@ -285,20 +296,13 @@ else version (Solaris)
 }
 else version( Android )
 {
-    version(X86)
-    {
-        alias c_ulong  fsblkcnt_t;
-        alias c_ulong  fsfilcnt_t;
-        alias c_long   clock_t;
-        alias uint     id_t;
-        alias int      key_t;
-        alias c_long   suseconds_t;
-        alias c_long   useconds_t;
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
-    }
+    alias c_ulong  fsblkcnt_t;
+    alias c_ulong  fsfilcnt_t;
+    alias c_long   clock_t;
+    alias uint     id_t;
+    alias int      key_t;
+    alias c_long   suseconds_t;
+    alias c_long   useconds_t;
 }
 else
 {
@@ -733,21 +737,14 @@ else version (Solaris)
 }
 else version( Android )
 {
-    version(X86)
+    struct pthread_attr_t
     {
-        struct pthread_attr_t
-        {
-            uint    flags;
-            void*   stack_base;
-            size_t  stack_size;
-            size_t  guard_size;
-            int     sched_policy;
-            int     sched_priority;
-        }
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
+        uint    flags;
+        void*   stack_base;
+        size_t  stack_size;
+        size_t  guard_size;
+        int     sched_policy;
+        int     sched_priority;
     }
 
     struct pthread_cond_t

--- a/src/core/sys/posix/sys/uio.d
+++ b/src/core/sys/posix/sys/uio.d
@@ -83,17 +83,10 @@ else version (Solaris)
 }
 else version( Android )
 {
-    version (X86)
+    struct iovec
     {
-        struct iovec
-        {
-            void* iov_base;
-            uint  iov_len;
-        }
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
+        void* iov_base;
+        uint  iov_len;
     }
 
     int readv(int, in iovec*, int);

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -292,15 +292,8 @@ else version( Android )
     enum CLOCK_REALTIME_HR = 4;
     enum TIMER_ABSTIME     = 0x01;
 
-    version(X86)
-    {
-        alias int clockid_t;
-        alias int timer_t;
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
-    }
+    alias int clockid_t;
+    alias int timer_t;
 
     int clock_getres(int, timespec*);
     int clock_gettime(int, timespec*);


### PR DESCRIPTION
When I first added Android support, it was based on the x86 headers of Android API 9, with any definitions coming from architecture-dependent headers placed inside a `version(X86)` block, just in case.  For this pull, I checked each of those blocks for the three 32-bit platforms from Android API 9, `X86`, `ARM`, and `MIPS32`.  If they're all the same, the versioning was removed.  If any arch varied, the definition was put inside its own `version(ARM)` block.

I did not check the new 64-bit platforms added with the latest Android API 21.  This pull overlaps and obsoletes some of #764, which has not been updated in a while.

I need to add one last bit to `core.stdc.errno`, but cannot do so till a change to that module in my previous #1010 is merged first.  Once that's merged, I can add the last necessary bit for this pull to be done.