### PR TITLE
fix benchmarks

### DIFF
--- a/benchmark/aabench/stomper.d
+++ b/benchmark/aabench/stomper.d
@@ -21,7 +21,7 @@ struct ExpRandom
 
     size_t front()
     {
-        return cast(size_t)lround(mean * -log(uniform!"()"(0.0, 1.0, gen)));
+        return cast(size_t)(mean * -log(uniform!"()"(0.0, 1.0, gen)) + 0.5);
     }
 
     alias gen this;

--- a/benchmark/gcbench/vdparser.extra/vdc/ast/type.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/ast/type.d
@@ -598,7 +598,7 @@ class ModifiedType : Type
 
         auto type = getType();
         type.semantic(sc);
-        ti.next = type.typeinfo;
+        ti.base = type.typeinfo;
 
         typeinfo = ti;
     }


### PR DESCRIPTION
stomper uses `lround` that is not implemented on Windows.
vdparser tries to write `TypeInfo_Const.next`, must be `base` now.