### PR TITLE
Tweak new AA implementation to get similar performance as the old one on Win32

### DIFF
--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -243,6 +243,7 @@ MANIFEST=\
 	\
 	src\rt\util\array.d \
 	src\rt\util\hash.d \
+	src\rt\util\mem.d \
 	src\rt\util\random.d \
 	src\rt\util\string.d \
 	src\rt\util\typeinfo.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -129,6 +129,7 @@ SRCS=\
 	\
 	src\rt\util\array.d \
 	src\rt\util\hash.d \
+	src\rt\util\mem.d \
 	src\rt\util\random.d \
 	src\rt\util\string.d \
 	src\rt\util\typeinfo.d \

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -55,7 +55,7 @@ private:
         buckets = allocBuckets(sz);
         firstUsed = cast(uint) buckets.length;
         entryTI = fakeEntryTI(ti.key, ti.value);
-        valoff = talign(keysz, ti.value.talign);
+        valoff = cast(uint) talign(keysz, ti.value.talign);
 
         import rt.lifetime : hasPostblit, unqualify;
 
@@ -72,7 +72,7 @@ private:
     uint firstUsed;
     immutable uint keysz;
     immutable uint valsz;
-    uint valoff;
+    immutable uint valoff;
     Flags flags;
 
     enum Flags : ubyte
@@ -174,10 +174,9 @@ private pure nothrow @nogc:
         return hash == HASH_DELETED;
     }
 
-    // not returning bool to avoid gratuitious codegen
-    @property int filled() const
+    @property bool filled() const
     {
-        return hash & HASH_FILLED_MARK;
+        return cast(ptrdiff_t)hash < 0;
     }
 }
 

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -197,6 +197,7 @@ Bucket[] allocBuckets(size_t dim) @trusted pure nothrow
 private void* allocEntry(in Impl* aa, in void* pkey)
 {
     import rt.lifetime : _d_newitemU;
+    import rt.util.mem;
 
     immutable akeysz = aa.keysz + aa.keypad;
     void* res = void;
@@ -208,9 +209,8 @@ private void* allocEntry(in Impl* aa, in void* pkey)
         res = GC.malloc(akeysz + aa.valsz, flags);
     }
 
-    res[0 .. aa.keysz] = pkey[0 .. aa.keysz]; // copy key
-    import core.stdc.string : memset; // explicitly use memset (Issue 14458)
-    memset(res + akeysz, 0, aa.valsz); // zero value
+    fastshortcopy(res, pkey, aa.keysz); // copy key
+    fastshortclear(res + akeysz, aa.valsz); // zero value
 
     return res;
 }

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -103,7 +103,7 @@ private:
     {
         for (size_t i = hash & mask, j = 1;; ++j)
         {
-            if (buckets[i].empty || buckets[i].deleted)
+            if (!buckets[i].filled)
                 return &buckets[i];
             i = (i + j) & mask;
         }
@@ -174,9 +174,10 @@ private pure nothrow @nogc:
         return hash == HASH_DELETED;
     }
 
-    @property bool filled() const
+    // not returning bool to avoid gratuitious codegen
+    @property int filled() const
     {
-        return !!(hash & HASH_FILLED_MARK);
+        return hash & HASH_FILLED_MARK;
     }
 }
 

--- a/src/rt/util/mem.d
+++ b/src/rt/util/mem.d
@@ -1,0 +1,56 @@
+/**
+ * Memory helper functions
+ *
+ * Copyright: Copyright Digital Mars 2015.
+ * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ */
+module rt.util.mem;
+
+// inlinable version of memset suited for clearing small memory blocks
+void fastshortclear(void* dest, size_t size)
+{
+    while (size >= 8)
+    {
+        *cast(ulong*)dest = 0;
+        dest += 8;
+        size -= 8;
+    }
+    if (size & 4)
+    {
+        *cast(uint*)dest = 0;
+        dest += 4;
+    }
+    if (size & 2)
+    {
+        *cast(ushort*)dest = 0;
+        dest += 2;
+    }
+    if (size & 1)
+        *cast(ubyte*)dest = 0;
+}
+
+// inlinable version of memcpy suited for copying small memory blocks
+void fastshortcopy(void* dest, const(void)* src, size_t size)
+{
+    while (size >= 8)
+    {
+        *cast(ulong*)dest = *cast(ulong*)src;
+        dest += 8;
+        src += 8;
+        size -= 8;
+    }
+    if (size & 4)
+    {
+        *cast(uint*)dest = *cast(uint*)src;
+        dest += 4;
+        src += 4;
+    }
+    if (size & 2)
+    {
+        *cast(ushort*)dest = *cast(ushort*)src;
+        dest += 2;
+        src += 2;
+    }
+    if (size & 1)
+        *cast(ubyte*)dest = *cast(ubyte*)src;
+}


### PR DESCRIPTION
This PR tries to restore performance of the AA after changing it to "state-of-the-art" dense hash map.

Results of AA related benchmarks on my mobile i7:
```
Win32:
                   oldAA     newAA     newAA_tweaked
R bulk             0.293 s   0.328 s   0.299 s
R int              0.106 s   0.117 s   0.115 s
R obj              0.129 s   0.128 s   0.127 s
R ptr              0.110 s   0.112 s   0.106 s
R resize           0.393 s   0.420 s   0.401 s
R stomper          1.026 s   1.007 s   1.013 s
R string           0.149 s   0.142 s   0.142 s
R testgc3          1.825 s   2.201 s   1.919 s
```

Win64 benefits from these optimizations aswell:
```
Win64:
                   oldAA     newAA     newAA_tweaked
R bulk             0.444 s   0.388 s   0.365 s
R int              0.139 s   0.116 s   0.113 s
R obj              0.164 s   0.144 s   0.142 s
R ptr              0.124 s   0.117 s   0.112 s
R resize           0.457 s   0.419 s   0.395 s
R stomper          0.410 s   0.389 s   0.386 s
R string           0.115 s   0.103 s   0.099 s
R testgc3          2.632 s   2.512 s   2.420 s
```

testgc3 gets slightly faster than the old implementation without the new `mix` function. 
