### PR TITLE
cleanup and rewrite rt.critical_

### DIFF
--- a/src/rt/critical_.d
+++ b/src/rt/critical_.d
@@ -15,202 +15,54 @@ module rt.critical_;
 
 nothrow:
 
-private
+import rt.monitor_, core.atomic;
+
+extern (C) void _d_critical_init()
 {
-    debug(PRINTF) import core.stdc.stdio;
-    import core.stdc.stdlib;
-
-    version( CRuntime_Glibc )
-    {
-        version = USE_PTHREADS;
-    }
-    else version( FreeBSD )
-    {
-        version = USE_PTHREADS;
-    }
-    else version( OSX )
-    {
-        version = USE_PTHREADS;
-    }
-    else version( Solaris )
-    {
-        version = USE_PTHREADS;
-    }
-    else version( CRuntime_Bionic )
-    {
-        version = USE_PTHREADS;
-    }
-
-    version( Windows )
-    {
-        import core.sys.windows.windows;
-
-        /* We don't initialize critical sections unless we actually need them.
-         * So keep a linked list of the ones we do use, and in the static destructor
-         * code, walk the list and release them.
-         */
-        struct D_CRITICAL_SECTION
-        {
-            D_CRITICAL_SECTION *next;
-            CRITICAL_SECTION cs;
-        }
-    }
-    else version( USE_PTHREADS )
-    {
-        import core.sys.posix.pthread;
-
-        /* We don't initialize critical sections unless we actually need them.
-         * So keep a linked list of the ones we do use, and in the static destructor
-         * code, walk the list and release them.
-         */
-        struct D_CRITICAL_SECTION
-        {
-            D_CRITICAL_SECTION *next;
-            pthread_mutex_t cs;
-        }
-    }
-    else
-    {
-        static assert(0, "Unsupported platform");
-    }
+    initMutex(cast(Mutex*)&gcs.mtx);
+    head = &gcs;
 }
 
-
-/* ================================= Win32 ============================ */
-
-version( Windows )
+extern (C) void _d_critical_term()
 {
-    version (CRuntime_DigitalMars)
-        pragma(lib, "snn.lib");
-
-    /******************************************
-     * Enter/exit critical section.
-     */
-
-    static __gshared D_CRITICAL_SECTION *dcs_list;
-    static __gshared D_CRITICAL_SECTION critical_section;
-    static __gshared int inited;
-
-    extern (C) void _d_criticalenter(D_CRITICAL_SECTION *dcs)
-    {
-        if (!dcs_list)
-        {
-            _STI_critical_init();
-            atexit(&_STD_critical_term);
-        }
-        debug(PRINTF) printf("_d_criticalenter(dcs = x%x)\n", dcs);
-        if (!dcs.next)
-        {
-            EnterCriticalSection(&critical_section.cs);
-            if (!dcs.next) // if, in the meantime, another thread didn't set it
-            {
-                dcs.next = dcs_list;
-                dcs_list = dcs;
-                InitializeCriticalSection(&dcs.cs);
-            }
-            LeaveCriticalSection(&critical_section.cs);
-        }
-        EnterCriticalSection(&dcs.cs);
-    }
-
-    extern (C) void _d_criticalexit(D_CRITICAL_SECTION *dcs)
-    {
-        debug(PRINTF) printf("_d_criticalexit(dcs = x%x)\n", dcs);
-        LeaveCriticalSection(&dcs.cs);
-    }
-
-    extern (C) void _STI_critical_init()
-    {
-        if (!inited)
-        {
-            debug(PRINTF) printf("_STI_critical_init()\n");
-            InitializeCriticalSection(&critical_section.cs);
-            dcs_list = &critical_section;
-            inited = 1;
-        }
-    }
-
-    extern (C) void _STD_critical_term()
-    {
-        if (inited)
-        {
-            debug(PRINTF) printf("_STI_critical_term()\n");
-            while (dcs_list)
-            {
-                debug(PRINTF) printf("\tlooping... %x\n", dcs_list);
-                DeleteCriticalSection(&dcs_list.cs);
-                dcs_list = dcs_list.next;
-            }
-            inited = 0;
-        }
-    }
+    for (auto p = head; p; p = p.next)
+        destroyMutex(cast(Mutex*)&p.mtx);
 }
 
-/* ================================= linux ============================ */
-
-version( USE_PTHREADS )
+extern (C) void _d_criticalenter(D_CRITICAL_SECTION* cs)
 {
-    /******************************************
-     * Enter/exit critical section.
-     */
+    ensureMutex(cast(shared(D_CRITICAL_SECTION*)) cs);
+    lockMutex(&cs.mtx);
+}
 
-    static __gshared D_CRITICAL_SECTION *dcs_list;
-    static __gshared D_CRITICAL_SECTION critical_section;
-    static __gshared pthread_mutexattr_t _criticals_attr;
+extern (C) void _d_criticalexit(D_CRITICAL_SECTION* cs)
+{
+    unlockMutex(&cs.mtx);
+}
 
-    extern (C) void _d_criticalenter(D_CRITICAL_SECTION *dcs)
+private:
+
+shared D_CRITICAL_SECTION* head;
+shared D_CRITICAL_SECTION gcs;
+
+struct D_CRITICAL_SECTION
+{
+    D_CRITICAL_SECTION* next;
+    Mutex mtx;
+}
+
+void ensureMutex(shared(D_CRITICAL_SECTION)* cs)
+{
+    if (atomicLoad!(MemoryOrder.acq)(cs.next) is null)
     {
-        if (!dcs_list)
+        lockMutex(cast(Mutex*)&gcs.mtx);
+        if (atomicLoad!(MemoryOrder.raw)(cs.next) is null)
         {
-            _STI_critical_init();
-            atexit(&_STD_critical_term);
+            initMutex(cast(Mutex*)&cs.mtx);
+            auto ohead = head;
+            head = cs;
+            atomicStore!(MemoryOrder.rel)(cs.next, ohead);
         }
-        debug(PRINTF) printf("_d_criticalenter(dcs = x%x)\n", dcs);
-        if (!dcs.next)
-        {
-            pthread_mutex_lock(&critical_section.cs);
-            if (!dcs.next) // if, in the meantime, another thread didn't set it
-            {
-                dcs.next = dcs_list;
-                dcs_list = dcs;
-                pthread_mutex_init(&dcs.cs, &_criticals_attr);
-            }
-            pthread_mutex_unlock(&critical_section.cs);
-        }
-        pthread_mutex_lock(&dcs.cs);
-    }
-
-    extern (C) void _d_criticalexit(D_CRITICAL_SECTION *dcs)
-    {
-        debug(PRINTF) printf("_d_criticalexit(dcs = x%x)\n", dcs);
-        pthread_mutex_unlock(&dcs.cs);
-    }
-
-    extern (C) void _STI_critical_init()
-    {
-        if (!dcs_list)
-        {
-            debug(PRINTF) printf("_STI_critical_init()\n");
-            pthread_mutexattr_init(&_criticals_attr);
-            pthread_mutexattr_settype(&_criticals_attr, PTHREAD_MUTEX_RECURSIVE);
-
-            // The global critical section doesn't need to be recursive
-            pthread_mutex_init(&critical_section.cs, null);
-            dcs_list = &critical_section;
-        }
-    }
-
-    extern (C) void _STD_critical_term()
-    {
-        if (dcs_list)
-        {
-            debug(PRINTF) printf("_STI_critical_term()\n");
-            while (dcs_list)
-            {
-                debug(PRINTF) printf("\tlooping... %x\n", dcs_list);
-                pthread_mutex_destroy(&dcs_list.cs);
-                dcs_list = dcs_list.next;
-            }
-        }
+        unlockMutex(cast(Mutex*)&gcs.mtx);
     }
 }

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -39,8 +39,8 @@ version (FreeBSD)
 
 extern (C) void _d_monitor_staticctor();
 extern (C) void _d_monitor_staticdtor();
-extern (C) void _STI_critical_init();
-extern (C) void _STD_critical_term();
+extern (C) void _d_critical_init();
+extern (C) void _d_critical_term();
 extern (C) void gc_init();
 extern (C) void gc_term();
 extern (C) void lifetime_init();
@@ -160,7 +160,7 @@ extern (C) int rt_init()
     if (atomicOp!"+="(_initCount, 1) > 1) return 1;
 
     _d_monitor_staticctor();
-    _STI_critical_init();
+    _d_critical_init();
 
     try
     {
@@ -177,7 +177,7 @@ extern (C) int rt_init()
         _initCount = 0;
         _d_print_throwable(t);
     }
-    _STD_critical_term();
+    _d_critical_term();
     _d_monitor_staticdtor();
     return 0;
 }
@@ -205,7 +205,7 @@ extern (C) int rt_term()
     }
     finally
     {
-        _STD_critical_term();
+        _d_critical_term();
         _d_monitor_staticdtor();
     }
     return 0;

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -37,8 +37,8 @@ version (FreeBSD)
     import core.stdc.fenv;
 }
 
-extern (C) void _STI_monitor_staticctor();
-extern (C) void _STD_monitor_staticdtor();
+extern (C) void _d_monitor_staticctor();
+extern (C) void _d_monitor_staticdtor();
 extern (C) void _STI_critical_init();
 extern (C) void _STD_critical_term();
 extern (C) void gc_init();
@@ -159,7 +159,7 @@ extern (C) int rt_init()
        rt_init. */
     if (atomicOp!"+="(_initCount, 1) > 1) return 1;
 
-    _STI_monitor_staticctor();
+    _d_monitor_staticctor();
     _STI_critical_init();
 
     try
@@ -178,7 +178,7 @@ extern (C) int rt_init()
         _d_print_throwable(t);
     }
     _STD_critical_term();
-    _STD_monitor_staticdtor();
+    _d_monitor_staticdtor();
     return 0;
 }
 
@@ -206,7 +206,7 @@ extern (C) int rt_term()
     finally
     {
         _STD_critical_term();
-        _STD_monitor_staticdtor();
+        _d_monitor_staticdtor();
     }
     return 0;
 }

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -1,23 +1,13 @@
 /**
  * Contains the implementation for object monitors.
  *
- * Copyright: Copyright Digital Mars 2000 - 2011.
+ * Copyright: Copyright Digital Mars 2000 - 2015.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   Walter Bright, Sean Kelly
- */
-
-/*          Copyright Digital Mars 2000 - 2011.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
+ * Authors:   Walter Bright, Sean Kelly, Martin Nowak
  */
 module rt.monitor_;
 
-//debug=PRINTF;
-
-///////////////////////////////////////////////////////////////////////////////
-// Monitor
-///////////////////////////////////////////////////////////////////////////////
+import core.atomic, core.stdc.stdlib, core.stdc.string;
 
 // NOTE: The dtor callback feature is only supported for monitors that are not
 //       supplied by the user.  The assumption is that any object with a user-
@@ -26,25 +16,18 @@ module rt.monitor_;
 //       may not be safe or desirable.  Thus, devt is only valid if impl is
 //       null.
 
-extern(C) void _d_setSameMutex(shared Object ownee, shared Object owner) nothrow
+extern (C) void _d_setSameMutex(shared Object ownee, shared Object owner) nothrow
 in
 {
     assert(ownee.__monitor is null);
 }
 body
 {
-    auto m = cast(shared(Monitor)*) owner.__monitor;
-
-    if (m is null)
-    {
-        _d_monitor_create(cast(Object) owner);
-        m = cast(shared(Monitor)*) owner.__monitor;
-    }
-
+    auto m = ensureMonitor(cast(Object) owner);
     auto i = m.impl;
     if (i is null)
     {
-        atomicOp!("+=")(m.refs, cast(size_t)1);
+        atomicOp!("+=")(m.refs, cast(size_t) 1);
         ownee.__monitor = owner.__monitor;
         return;
     }
@@ -55,96 +38,49 @@ body
 
 extern (C) void _d_monitordelete(Object h, bool det)
 {
-    // det is true when the object is being destroyed deterministically (ie.
-    // when it is explicitly deleted or is a scope object whose time is up).
-    Monitor* m = getMonitor(h);
+    auto m = getMonitor(h);
+    if (m is null)
+        return;
 
-    if (m !is null)
+    if (m.impl)
     {
-        IMonitor i = m.impl;
-        if (i is null)
-        {
-            auto s = cast(shared(Monitor)*) m;
-            if(!atomicOp!("-=")(s.refs, cast(size_t) 1))
-            {
-                _d_monitor_devt(m, h);
-                _d_monitor_destroy(h);
-                setMonitor(h, null);
-            }
-            return;
-        }
-        // NOTE: Since a monitor can be shared via setSameMutex it isn't safe
-        //       to explicitly delete user-created monitors--there's no
-        //       refcount and it may have multiple owners.
-        /+
-        if (det && (cast(void*) i) !is (cast(void*) h))
-        {
-            destroy(i);
-            GC.free(cast(void*)i);
-        }
-        +/
+        // let the GC collect the monitor
+        setMonitor(h, null);
+    }
+    else if (!atomicOp!("-=")(m.refs, cast(size_t) 1))
+    {
+        // refcount == 0 means unshared => no synchronization required
+        disposeEvent(cast(Monitor*) m, h);
+        deleteMonitor(cast(Monitor*) m);
         setMonitor(h, null);
     }
 }
 
 extern (C) void _d_monitorenter(Object h)
 {
-    Monitor* m = getMonitor(h);
-
-    if (m is null)
-    {
-        _d_monitor_create(h);
-        m = getMonitor(h);
-    }
-
-    IMonitor i = m.impl;
-
+    auto m = cast(Monitor*) ensureMonitor(h);
+    auto i = m.impl;
     if (i is null)
-    {
-        _d_monitor_lock(h);
-        return;
-    }
-    i.lock();
+        lockMutex(&m.mtx);
+    else
+        i.lock();
 }
 
 extern (C) void _d_monitorexit(Object h)
 {
-    Monitor* m = getMonitor(h);
-    IMonitor i = m.impl;
-
+    auto m = cast(Monitor*) getMonitor(h);
+    auto i = m.impl;
     if (i is null)
-    {
-        _d_monitor_unlock(h);
-        return;
-    }
-    i.unlock();
-}
-
-extern (C) void _d_monitor_devt(Monitor* m, Object h)
-{
-    if (m.devt.length)
-    {
-        DEvent[] devt;
-
-        synchronized (h)
-        {
-            devt = m.devt;
-            m.devt = null;
-        }
-        foreach (v; devt)
-        {
-            if (v)
-                v(h);
-        }
-        free(devt.ptr);
-    }
+        unlockMutex(&m.mtx);
+    else
+        i.unlock();
 }
 
 extern (C) void rt_attachDisposeEvent(Object h, DEvent e)
 {
     synchronized (h)
     {
-        Monitor* m = getMonitor(h);
+        auto m = cast(Monitor*) getMonitor(h);
         assert(m.impl is null);
 
         foreach (ref v; m.devt)
@@ -157,13 +93,14 @@ extern (C) void rt_attachDisposeEvent(Object h, DEvent e)
         }
 
         auto len = m.devt.length + 4; // grow by 4 elements
-        auto pos = m.devt.length;     // insert position
+        auto pos = m.devt.length; // insert position
         auto p = realloc(m.devt.ptr, DEvent.sizeof * len);
         import core.exception : onOutOfMemoryError;
+
         if (!p)
             onOutOfMemoryError();
-        m.devt = (cast(DEvent*)p)[0 .. len];
-        m.devt[pos+1 .. len] = null;
+        m.devt = (cast(DEvent*) p)[0 .. len];
+        m.devt[pos + 1 .. len] = null;
         m.devt[pos] = e;
     }
 }
@@ -172,16 +109,14 @@ extern (C) void rt_detachDisposeEvent(Object h, DEvent e)
 {
     synchronized (h)
     {
-        Monitor* m = getMonitor(h);
+        auto m = cast(Monitor*) getMonitor(h);
         assert(m.impl is null);
 
         foreach (p, v; m.devt)
         {
             if (v == e)
             {
-                memmove(&m.devt[p],
-                        &m.devt[p+1],
-                        (m.devt.length - p - 1) * DEvent.sizeof);
+                memmove(&m.devt[p], &m.devt[p + 1], (m.devt.length - p - 1) * DEvent.sizeof);
                 m.devt[$ - 1] = null;
                 return;
             }
@@ -191,263 +126,156 @@ extern (C) void rt_detachDisposeEvent(Object h, DEvent e)
 
 nothrow:
 
-private
+extern (C) void _d_monitor_staticctor()
 {
-    debug(PRINTF) import core.stdc.stdio;
-    import core.stdc.stdlib;
-    import core.stdc.string;
-    import core.atomic;
-
-    version( CRuntime_Glibc )
+    version (Posix)
     {
-        version = USE_PTHREADS;
+        pthread_mutexattr_init(&gattr);
+        pthread_mutexattr_settype(&gattr, PTHREAD_MUTEX_RECURSIVE);
     }
-    else version( FreeBSD )
-    {
-        version = USE_PTHREADS;
-    }
-    else version( OSX )
-    {
-        version = USE_PTHREADS;
-    }
-    else version( Solaris )
-    {
-        version = USE_PTHREADS;
-    }
-    else version( CRuntime_Bionic )
-    {
-        version = USE_PTHREADS;
-    }
-
-    // This is what the monitor reference in Object points to
-    alias Object.Monitor        IMonitor;
-    alias void delegate(Object) DEvent;
-
-    version( Windows )
-    {
-        version (CRuntime_DigitalMars)
-        {
-            pragma(lib, "snn.lib");
-        }
-        else version (CRuntime_Microsoft)
-        {
-            pragma(lib, "libcmt.lib");
-            pragma(lib, "oldnames.lib");
-        }
-        import core.sys.windows.windows;
-
-        struct Monitor
-        {
-            IMonitor impl; // for user-level monitors
-            DEvent[] devt; // for internal monitors
-            size_t   refs; // reference count
-            CRITICAL_SECTION mon;
-        }
-    }
-    else version( USE_PTHREADS )
-    {
-        import core.sys.posix.pthread;
-
-        struct Monitor
-        {
-            IMonitor impl; // for user-level monitors
-            DEvent[] devt; // for internal monitors
-            size_t   refs; // reference count
-            pthread_mutex_t mon;
-        }
-    }
-    else
-    {
-        static assert(0, "Unsupported platform");
-    }
-
-    Monitor* getMonitor(Object h) pure
-    {
-        return cast(Monitor*) h.__monitor;
-    }
-
-    void setMonitor(Object h, Monitor* m) pure
-    {
-        h.__monitor = m;
-    }
-
-    static __gshared int inited;
+    initMutex(&gmtx);
 }
 
-
-/* =============================== Win32 ============================ */
-
-version( Windows )
+extern (C) void _d_monitor_staticdtor()
 {
-    static __gshared CRITICAL_SECTION _monitor_critsec;
+    destroyMutex(&gmtx);
+    version (Posix)
+        pthread_mutexattr_destroy(&gattr);
+}
 
-    extern (C) void _STI_monitor_staticctor()
+private:
+
+// This is what the monitor reference in Object points to
+alias IMonitor = Object.Monitor;
+alias DEvent = void delegate(Object);
+
+version (Windows)
+{
+    version (CRuntime_DigitalMars)
     {
-        debug(PRINTF) printf("+_STI_monitor_staticctor()\n");
-        if (!inited)
-        {
-            InitializeCriticalSection(&_monitor_critsec);
-            inited = 1;
-        }
-        debug(PRINTF) printf("-_STI_monitor_staticctor()\n");
+        pragma(lib, "snn.lib");
+    }
+    else version (CRuntime_Microsoft)
+    {
+        pragma(lib, "libcmt.lib");
+        pragma(lib, "oldnames.lib");
+    }
+    import core.sys.windows.windows;
+
+    alias Mutex = CRITICAL_SECTION;
+
+    alias initMutex = InitializeCriticalSection;
+    alias destroyMutex = DeleteCriticalSection;
+    alias lockMutex = EnterCriticalSection;
+    alias unlockMutex = LeaveCriticalSection;
+}
+else version (Posix)
+{
+    import core.sys.posix.pthread;
+
+    alias Mutex = pthread_mutex_t;
+    __gshared pthread_mutexattr_t gattr;
+
+    void initMutex(pthread_mutex_t* mtx)
+    {
+        pthread_mutex_init(mtx, &gattr) && assert(0);
     }
 
-    extern (C) void _STD_monitor_staticdtor()
+    void destroyMutex(pthread_mutex_t* mtx)
     {
-        debug(PRINTF) printf("+_STI_monitor_staticdtor() - d\n");
-        if (inited)
-        {
-            inited = 0;
-            DeleteCriticalSection(&_monitor_critsec);
-        }
-        debug(PRINTF) printf("-_STI_monitor_staticdtor() - d\n");
+        pthread_mutex_destroy(mtx) && assert(0);
     }
 
-    extern (C) void _d_monitor_create(Object h)
+    void lockMutex(pthread_mutex_t* mtx)
     {
-        /*
-         * NOTE: Assume this is only called when h.__monitor is null prior to the
-         * call.  However, please note that another thread may call this function
-         * at the same time, so we can not assert this here.  Instead, try and
-         * create a lock, and if one already exists then forget about it.
-         */
+        pthread_mutex_lock(mtx) && assert(0);
+    }
 
-        debug(PRINTF) printf("+_d_monitor_create(%p)\n", h);
-        assert(h);
-        Monitor *cs;
-        EnterCriticalSection(&_monitor_critsec);
-        if (!h.__monitor)
-        {
-            cs = cast(Monitor *)calloc(Monitor.sizeof, 1);
-            assert(cs);
-            InitializeCriticalSection(&cs.mon);
-            setMonitor(h, cs);
-            cs.refs = 1;
-            cs = null;
-        }
-        LeaveCriticalSection(&_monitor_critsec);
-        if (cs)
-            free(cs);
+    void unlockMutex(pthread_mutex_t* mtx)
+    {
+        pthread_mutex_unlock(mtx) && assert(0);
+    }
+}
+else
+{
+    static assert(0, "Unsupported platform");
+}
+
+struct Monitor
+{
+    IMonitor impl; // for user-level monitors
+    DEvent[] devt; // for internal monitors
+    size_t refs; // reference count
+    Mutex mtx;
+}
+
+@property ref shared(Monitor*) monitor(Object h) pure nothrow
+{
+    return *cast(shared Monitor**)&h.__monitor;
+}
+
+private shared(Monitor)* getMonitor(Object h) pure
+{
+    return atomicLoad!(MemoryOrder.acq)(h.monitor);
+}
+
+void setMonitor(Object h, shared(Monitor)* m) pure
+{
+    atomicStore!(MemoryOrder.rel)(h.monitor, m);
+}
+
+__gshared Mutex gmtx;
+
+shared(Monitor)* ensureMonitor(Object h)
+{
+    if (auto m = getMonitor(h))
+        return m;
+
+    auto m = cast(Monitor*) calloc(Monitor.sizeof, 1);
+    assert(m);
+    initMutex(&m.mtx);
+
+    bool success;
+    lockMutex(&gmtx);
+    if (getMonitor(h) is null)
+    {
+        m.refs = 1;
+        setMonitor(h, cast(shared) m);
+        success = true;
+    }
+    unlockMutex(&gmtx);
+
+    if (success)
+    {
         // Set the finalize bit so that the monitor gets collected (Bugzilla 14573)
         import core.memory : GC;
+
         if (!(typeid(h).m_flags & TypeInfo_Class.ClassFlags.hasDtor))
-            GC.setAttr(cast(void*)h, GC.BlkAttr.FINALIZE);
-        debug(PRINTF) printf("-_d_monitor_create(%p)\n", h);
+            GC.setAttr(cast(void*) h, GC.BlkAttr.FINALIZE);
+        return cast(shared(Monitor)*) m;
     }
-
-    extern (C) void _d_monitor_destroy(Object h)
+    else // another thread succeeded instead
     {
-        debug(PRINTF) printf("+_d_monitor_destroy(%p)\n", h);
-        assert(h && h.__monitor && !getMonitor(h).impl);
-        DeleteCriticalSection(&getMonitor(h).mon);
-        free(h.__monitor);
-        setMonitor(h, null);
-        debug(PRINTF) printf("-_d_monitor_destroy(%p)\n", h);
-    }
-
-    extern (C) void _d_monitor_lock(Object h)
-    {
-        debug(PRINTF) printf("+_d_monitor_acquire(%p)\n", h);
-        assert(h && h.__monitor && !getMonitor(h).impl);
-        EnterCriticalSection(&getMonitor(h).mon);
-        debug(PRINTF) printf("-_d_monitor_acquire(%p)\n", h);
-    }
-
-    extern (C) void _d_monitor_unlock(Object h)
-    {
-        debug(PRINTF) printf("+_d_monitor_release(%p)\n", h);
-        assert(h && h.__monitor && !getMonitor(h).impl);
-        LeaveCriticalSection(&getMonitor(h).mon);
-        debug(PRINTF) printf("-_d_monitor_release(%p)\n", h);
+        deleteMonitor(m);
+        return getMonitor(h);
     }
 }
 
-/* =============================== linux ============================ */
-
-version( USE_PTHREADS )
+void deleteMonitor(Monitor* m)
 {
-    // Includes attribute fixes from David Friedman's GDC port
-    static __gshared pthread_mutex_t _monitor_critsec;
-    static __gshared pthread_mutexattr_t _monitors_attr;
+    destroyMutex(&m.mtx);
+    free(m);
+}
 
-    extern (C) void _STI_monitor_staticctor()
+void disposeEvent(Monitor* m, Object h)
+{
+    foreach (v; m.devt)
     {
-        if (!inited)
-        {
-            pthread_mutexattr_init(&_monitors_attr);
-            pthread_mutexattr_settype(&_monitors_attr, PTHREAD_MUTEX_RECURSIVE);
-            pthread_mutex_init(&_monitor_critsec, &_monitors_attr);
-            inited = 1;
-        }
+        if (v)
+            v(h);
     }
-
-    extern (C) void _STD_monitor_staticdtor()
-    {
-        if (inited)
-        {
-            inited = 0;
-            pthread_mutex_destroy(&_monitor_critsec);
-            pthread_mutexattr_destroy(&_monitors_attr);
-        }
-    }
-
-    extern (C) void _d_monitor_create(Object h)
-    {
-        /*
-         * NOTE: Assume this is only called when h.__monitor is null prior to the
-         * call.  However, please note that another thread may call this function
-         * at the same time, so we can not assert this here.  Instead, try and
-         * create a lock, and if one already exists then forget about it.
-         */
-
-        debug(PRINTF) printf("+_d_monitor_create(%p)\n", h);
-        assert(h);
-        Monitor *cs;
-        pthread_mutex_lock(&_monitor_critsec);
-        if (!h.__monitor)
-        {
-            cs = cast(Monitor *)calloc(Monitor.sizeof, 1);
-            assert(cs);
-            pthread_mutex_init(&cs.mon, &_monitors_attr);
-            setMonitor(h, cs);
-            cs.refs = 1;
-            cs = null;
-        }
-        pthread_mutex_unlock(&_monitor_critsec);
-        if (cs)
-            free(cs);
-        // Set the finalize bit so that the monitor gets collected (Bugzilla 14573)
-        import core.memory : GC;
-        if (!(typeid(h).m_flags & TypeInfo_Class.ClassFlags.hasDtor))
-            GC.setAttr(cast(void*)h, GC.BlkAttr.FINALIZE);
-        debug(PRINTF) printf("-_d_monitor_create(%p)\n", h);
-    }
-
-    extern (C) void _d_monitor_destroy(Object h)
-    {
-        debug(PRINTF) printf("+_d_monitor_destroy(%p)\n", h);
-        assert(h && h.__monitor && !getMonitor(h).impl);
-        pthread_mutex_destroy(&getMonitor(h).mon);
-        free(h.__monitor);
-        setMonitor(h, null);
-        debug(PRINTF) printf("-_d_monitor_destroy(%p)\n", h);
-    }
-
-    extern (C) void _d_monitor_lock(Object h)
-    {
-        debug(PRINTF) printf("+_d_monitor_acquire(%p)\n", h);
-        assert(h && h.__monitor && !getMonitor(h).impl);
-        pthread_mutex_lock(&getMonitor(h).mon);
-        debug(PRINTF) printf("-_d_monitor_acquire(%p)\n", h);
-    }
-
-    extern (C) void _d_monitor_unlock(Object h)
-    {
-        debug(PRINTF) printf("+_d_monitor_release(%p)\n", h);
-        assert(h && h.__monitor && !getMonitor(h).impl);
-        pthread_mutex_unlock(&getMonitor(h).mon);
-        debug(PRINTF) printf("-_d_monitor_release(%p)\n", h);
-    }
+    if (m.devt.ptr)
+        free(m.devt.ptr);
 }
 
 // Bugzilla 14573
@@ -456,8 +284,8 @@ unittest
     import core.memory : GC;
 
     auto obj = new Object;
-    assert(!(GC.getAttr(cast(void*)obj) & GC.BlkAttr.FINALIZE));
-    _d_monitor_create(obj);
+    assert(!(GC.getAttr(cast(void*) obj) & GC.BlkAttr.FINALIZE));
+    ensureMonitor(obj);
     assert(getMonitor(obj) !is null);
-    assert(GC.getAttr(cast(void*)obj) & GC.BlkAttr.FINALIZE);
+    assert(GC.getAttr(cast(void*) obj) & GC.BlkAttr.FINALIZE);
 }

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -143,7 +143,7 @@ extern (C) void _d_monitor_staticdtor()
         pthread_mutexattr_destroy(&gattr);
 }
 
-private:
+package:
 
 // This is what the monitor reference in Object points to
 alias IMonitor = Object.Monitor;
@@ -208,6 +208,8 @@ struct Monitor
     size_t refs; // reference count
     Mutex mtx;
 }
+
+private:
 
 @property ref shared(Monitor*) monitor(Object h) pure nothrow
 {

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -441,4 +441,3 @@ version( USE_PTHREADS )
         debug(PRINTF) printf("-_d_monitor_release(%p)\n", h);
     }
 }
-


### PR DESCRIPTION
- reuse mutex declarations from rt.monitor_
- fix race condition (incorrect double checked locking)
- modernize code for readability
- use shared(D_CRITICAL_SECTION)* when dealing with
  unsynchronized data
- replace STI/STD style C constructors
- fix Issue 6607
- hopefully fix Issue 14584 - spurious autotester deadlocks

[Issue 14584 – spurious autotester deadlocks](https://issues.dlang.org/show_bug.cgi?id=14584)
DEPENDS ON: #1272