### PR TITLE
Some updates to MonoTime to better initialize the ticks per second

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -61,37 +61,6 @@ else                   import core.stdc.stdio : sprintf, printf; // needed to ou
 
 import core.time;
 alias currTime = MonoTime.currTime;
-debug(PROFILE_API)
-{
-    long currTicks() nothrow @nogc
-    {
-        // MonoTime.ticksPerSecond may not be ready yet. So just avoid it altogether
-        // this is copied from core.time.MonoTime.currTime
-        //return MonoTime.ticksPerSecond ? MonoTime.currTime.ticks : 0;
-        version(Windows)
-        {
-            import core.sys.windows.windows;
-
-            long ticks;
-            if(QueryPerformanceCounter(&ticks) == 0)
-            {
-                // This probably cannot happen on Windows 95 or later
-                assert(0, "Call to QueryPerformanceCounter failed.");
-            }
-            return ticks;
-        }
-        else version(OSX)
-            return mach_absolute_time();
-        else version(Posix)
-        {
-            timespec ts;
-            if(clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
-                assert(0, "Call to clock_gettime failed.");
-
-            return ts.tv_sec * 1_000_000_000L + ts.tv_nsec;
-        }
-    }
-}
 
 debug(PRINTF_TO_FILE)
 {
@@ -381,14 +350,14 @@ struct GC
     {
         debug(PROFILE_API)
         {
-            long tm = (GC.config.profile > 1 ? currTicks : 0);
+            long tm = (GC.config.profile > 1 ? currTime.ticks : 0);
         }
 
         bool locked = (gcLock.lock(), true);
 
         debug(PROFILE_API)
         {
-            long tm2 = (GC.config.profile > 1 ? currTicks : 0);
+            long tm2 = (GC.config.profile > 1 ? currTime.ticks : 0);
         }
     }
 

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -50,6 +50,7 @@ extern (C) void rt_moduleDtor();
 extern (C) void rt_moduleTlsDtor();
 extern (C) void thread_joinAll();
 extern (C) bool runModuleUnitTests();
+extern (C) void _d_initMonoTime();
 
 version (OSX)
 {
@@ -165,6 +166,9 @@ extern (C) int rt_init()
     try
     {
         initSections();
+        // this initializes mono time before anything else to allow usage
+        // in other druntime systems.
+        _d_initMonoTime();
         gc_init();
         initStaticDataGC();
         lifetime_init();


### PR DESCRIPTION
Also:
- Factor out translation of ClockType enums to POSIX clock types as a parameter to clock_gettime, etc.
- Remove reimplementation of getting MonoTime.ticks from GC code, since the initializer is now run before the gc initializer.
- Factor out translation of clock type to clock type enum index.
- Factor out traits lookup of enum name.