### PR TITLE
Fix issue 14617 - PTHREAD_MUTEX_INITIALIZER does not work on OSX

### DIFF
--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -162,8 +162,8 @@ else version( OSX )
         PTHREAD_EXPLICIT_SCHED  = 2
     }
 
-    enum PTHREAD_MUTEX_INITIALIZER  = pthread_mutex_t.init;
-    enum PTHREAD_ONCE_INIT          = pthread_once_t.init;
+    enum PTHREAD_MUTEX_INITIALIZER  = pthread_mutex_t(0x32AAABA7);
+    enum PTHREAD_ONCE_INIT          = pthread_once_t(0x30b1bcba);
 
     enum
     {


### PR DESCRIPTION
This adds an initializer to pthread_mutex_t so it is correct by default on OSX. Not sure if this will work, it failed my unittest build on OSX with a link error. I think possibly types.d is not included in the unit test build.