### PR TITLE
Use osmodel.mak from dmd repo

### DIFF
--- a/osmodel.mak
+++ b/osmodel.mak
@@ -1,0 +1,52 @@
+# This Makefile snippet detects the OS and the architecture MODEL
+# Keep this file in sync between druntime, phobos, and dmd repositories!
+
+ifeq (,$(OS))
+  uname_S:=$(shell uname -s)
+  ifeq (Darwin,$(uname_S))
+    OS:=osx
+  endif
+  ifeq (Linux,$(uname_S))
+    OS:=linux
+  endif
+  ifeq (FreeBSD,$(uname_S))
+    OS:=freebsd
+  endif
+  ifeq (OpenBSD,$(uname_S))
+    OS:=openbsd
+  endif
+  ifeq (Solaris,$(uname_S))
+    OS:=solaris
+  endif
+  ifeq (SunOS,$(uname_S))
+    OS:=solaris
+  endif
+  ifeq (,$(OS))
+    $(error Unrecognized or unsupported OS for uname: $(uname_S))
+  endif
+endif
+
+# When running make from XCode it may set environment var OS=MACOS.
+# Adjust it here:
+ifeq (MACOS,$(OS))
+  OS:=osx
+endif
+
+ifeq (,$(MODEL))
+  ifeq ($(OS), solaris)
+    uname_M:=$(shell isainfo -n)
+  else
+    uname_M:=$(shell uname -m)
+  endif
+  ifneq (,$(findstring $(uname_M),x86_64 amd64))
+    MODEL:=64
+  endif
+  ifneq (,$(findstring $(uname_M),i386 i586 i686))
+    MODEL:=32
+  endif
+  ifeq (,$(MODEL))
+    $(error Cannot figure 32/64 model from uname -m: $(uname_M))
+  endif
+endif
+
+MODEL_FLAG:=-m$(MODEL)

--- a/posix.mak
+++ b/posix.mak
@@ -5,47 +5,7 @@
 
 QUIET:=@
 
-ifeq (,$(OS))
-  uname_S:=$(shell uname -s)
-  ifeq (Darwin,$(uname_S))
-    OS:=osx
-  endif
-  ifeq (Linux,$(uname_S))
-    OS:=linux
-  endif
-  ifeq (FreeBSD,$(uname_S))
-    OS:=freebsd
-  endif
-  ifeq (OpenBSD,$(uname_S))
-    OS:=openbsd
-  endif
-  ifeq (Solaris,$(uname_S))
-    OS:=solaris
-  endif
-  ifeq (SunOS,$(uname_S))
-    OS:=solaris
-  endif
-  ifeq (,$(OS))
-    $(error Unrecognized or unsupported OS for uname: $(uname_S))
-  endif
-endif
-
-ifeq (,$(MODEL))
-  ifeq ($(OS),solaris)
-    uname_M:=$(shell isainfo -n)
-  else
-    uname_M:=$(shell uname -m)
-  endif
-  ifneq (,$(findstring $(uname_M),x86_64 amd64))
-    MODEL:=64
-  endif
-  ifneq (,$(findstring $(uname_M),i386 i586 i686))
-    MODEL:=32
-  endif
-  ifeq (,$(MODEL))
-    $(error Cannot figure 32/64 model from uname -m: $(uname_M))
-  endif
-endif
+include osmodel.mak
 
 DMD=../dmd/src/dmd
 INSTALL_DIR=../install
@@ -53,7 +13,6 @@ INSTALL_DIR=../install
 DOCDIR=doc
 IMPDIR=import
 
-MODEL_FLAG:=-m$(MODEL)
 override PIC:=$(if $(PIC),-fPIC,)
 
 ifeq (osx,$(OS))


### PR DESCRIPTION
There were slight difference between the logic in `posix.mak` compared to `osmodel.mak` (DRY)

Also see https://github.com/D-Programming-Language/dmd/pull/4684