### PR TITLE
Make catching of exceptions from Fibers optional

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3445,7 +3445,7 @@ private
         obj.m_ctxt.tstack = obj.m_ctxt.bstack;
         obj.m_state = Fiber.State.EXEC;
 
-        try
+        if( obj.catch_exceptions ) try
         {
             obj.run();
         }
@@ -3453,6 +3453,8 @@ private
         {
             obj.m_unhandled = t;
         }
+        else
+            obj.run();
 
         static if( __traits( compiles, ucontext_t ) )
           obj.m_ucur = &obj.m_utxt;
@@ -3864,11 +3866,12 @@ class Fiber
      * Params:
      *  fn = The fiber function.
      *  sz = The stack size for this fiber.
+     *  ce = If true, exceptions will be caught and assigned to m_unhandled
      *
      * In:
      *  fn must not be null.
      */
-    this( void function() fn, size_t sz = PAGESIZE*4 ) nothrow
+    this( void function() fn, size_t sz = PAGESIZE*4, bool ce = true ) nothrow
     in
     {
         assert( fn );
@@ -3876,6 +3879,7 @@ class Fiber
     body
     {
         allocStack( sz );
+        catch_exceptions = ce;
         reset( fn );
     }
 
@@ -3887,11 +3891,12 @@ class Fiber
      * Params:
      *  dg = The fiber function.
      *  sz = The stack size for this fiber.
+     *  ce = If true, exceptions will be caught and assigned to m_unhandled
      *
      * In:
      *  dg must not be null.
      */
-    this( void delegate() dg, size_t sz = PAGESIZE*4 ) nothrow
+    this( void delegate() dg, size_t sz = PAGESIZE*4, bool ce = true ) nothrow
     in
     {
         assert( dg );
@@ -3899,6 +3904,7 @@ class Fiber
     body
     {
         allocStack( sz );
+        catch_exceptions = ce;
         reset( dg );
     }
 
@@ -4172,6 +4178,13 @@ class Fiber
             }
         }
     }
+
+    //
+    // If true, exceptions thrown inside the fiber will be caught and assigned
+    // to m_unhandled, otherwise exceptions will cause a termination of the
+    // program
+    //
+    bool catch_exceptions;
 
 private:
     //


### PR DESCRIPTION
This commit allows exceptions from Fibers to be completely uncaught thus
causing a termination of the program and, depending on the configuration,
creation of a core dump.

An attached debugger can then be used to properly investigate the status of the
program at the time of the failure.