### PR TITLE
Fixed DDoc warnings

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1901,6 +1901,7 @@ unittest
 * Mangles a C function or variable.
 *
 * Params:
+*  sym = The C symbol to mangle.
 *  dst = An optional destination buffer.
 *
 * Returns:

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -341,7 +341,7 @@ extern (C) void dmd_coverDestPath(string path);
  * Enable merging of coverage reports with existing data.
  *
  * Params:
- *  merge = enable/disable coverage merge mode
+ *  flag = enable/disable coverage merge mode
  */
 extern (C) void dmd_coverSetMerge(bool flag);
 


### PR DESCRIPTION
Found by adding -w to Ddoc command line.