### PR TITLE
Windows:unhandled exception dump should not show dialog if stderr is redirected

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -517,7 +517,10 @@ extern (C) void _d_print_throwable(Throwable t)
     // Show a message box instead.
     version (Windows)
     {
-        if (!GetConsoleWindow())
+        // ensure the exception is shown at the beginning of the line, while also
+        // checking whether stderr is a valid file
+        int written = fprintf(stderr, "\n");
+        if (written <= 0)
         {
             static struct WSink
             {


### PR DESCRIPTION
Followup for #703