### PR TITLE
detab, tolf, remove trailing whitespace

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -211,9 +211,9 @@ MAKEFILES = $(filter mak/% %.mak,$(MANIFEST))
 NOT_MAKEFILES = $(filter-out $(MAKEFILES),$(MANIFEST))
 
 checkwhitespace:
-	grep -n -U -e "[ \t]$$$$" -e "\r" $(MAKEFILES) ; test "$$?" -ne 0
-	grep -n -U -e " $$$$" -e "\r|\t" $(NOT_MAKEFILES) ; test "$$?" -ne 0
-	
+	grep -n -P "([ \t]$$|\r)" $(MAKEFILES) ; test "$$?" -ne 0
+	grep -n -P "( $$|\r\t)" $(NOT_MAKEFILES) ; test "$$?" -ne 0
+
 detab:
 	detab $(MANIFEST)
 	tolf $(MANIFEST)

--- a/posix.mak
+++ b/posix.mak
@@ -206,6 +206,14 @@ test/%/.run: test/%/Makefile
 	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) DMD=$(abspath $(DMD)) \
 		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) QUIET=$(QUIET) LINKDL=$(LINKDL)
 
+#################### test for undesired white spaces ##########################
+MAKEFILES = $(filter mak/% %.mak,$(MANIFEST))
+NOT_MAKEFILES = $(filter-out $(MAKEFILES),$(MANIFEST))
+
+checkwhitespace:
+	grep -n -e "[ \t]$$" -e "\r" $(MAKEFILES) ; test "$$?" -ne 0
+	grep -n -e " $$" -e "\r|\t" $(NOT_MAKEFILES) ; test "$$?" -ne 0
+	
 detab:
 	detab $(MANIFEST)
 	tolf $(MANIFEST)
@@ -231,7 +239,7 @@ test/%/.clean: test/%/Makefile
 	$(MAKE) -C test/$* clean
 
 .PHONY : auto-tester-build
-auto-tester-build: target
+auto-tester-build: target checkwhitespace
 
 .PHONY : auto-tester-test
 auto-tester-test: unittest

--- a/posix.mak
+++ b/posix.mak
@@ -211,8 +211,8 @@ MAKEFILES = $(filter mak/% %.mak,$(MANIFEST))
 NOT_MAKEFILES = $(filter-out $(MAKEFILES),$(MANIFEST))
 
 checkwhitespace:
-	grep -n -e "[ \t]$$" -e "\r" $(MAKEFILES) ; test "$$?" -ne 0
-	grep -n -e " $$" -e "\r|\t" $(NOT_MAKEFILES) ; test "$$?" -ne 0
+	grep -n -U -e "[ \t]$$" -e "\r" $(MAKEFILES) ; test "$$?" -ne 0
+	grep -n -U -e " $$" -e "\r|\t" $(NOT_MAKEFILES) ; test "$$?" -ne 0
 	
 detab:
 	detab $(MANIFEST)

--- a/posix.mak
+++ b/posix.mak
@@ -211,8 +211,8 @@ MAKEFILES = $(filter mak/% %.mak,$(MANIFEST))
 NOT_MAKEFILES = $(filter-out $(MAKEFILES),$(MANIFEST))
 
 checkwhitespace:
-	grep -n -U -e "[ \t]$$" -e "\r" $(MAKEFILES) ; test "$$?" -ne 0
-	grep -n -U -e " $$" -e "\r|\t" $(NOT_MAKEFILES) ; test "$$?" -ne 0
+	grep -n -U -e "[ \t]$$$$" -e "\r" $(MAKEFILES) ; test "$$?" -ne 0
+	grep -n -U -e " $$$$" -e "\r|\t" $(NOT_MAKEFILES) ; test "$$?" -ne 0
 	
 detab:
 	detab $(MANIFEST)

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -170,10 +170,10 @@ else version( AsmX86_32 )
         static if (T.sizeof == 1) asm pure nothrow @nogc { lock; xadd[EDX], AL; }
         else static if (T.sizeof == 2) asm pure nothrow @nogc { lock; xadd[EDX], AX; }
         else static if (T.sizeof == 4) asm pure nothrow @nogc { lock; xadd[EDX], EAX; }
-            
-        asm pure nothrow @nogc 
-        { 
-            mov tmp, EAX; 
+
+        asm pure nothrow @nogc
+        {
+            mov tmp, EAX;
         }
 
         return cast(T)tmp;
@@ -688,10 +688,10 @@ else version( AsmX86_64 )
         else static if (T.sizeof == 2) asm pure nothrow @nogc { lock; xadd[RDX], AX; }
         else static if (T.sizeof == 4) asm pure nothrow @nogc { lock; xadd[RDX], EAX; }
         else static if (T.sizeof == 8) asm pure nothrow @nogc { lock; xadd[RDX], RAX; }
-        
-        asm pure nothrow @nogc 
-        { 
-            mov tmp, RAX; 
+
+        asm pure nothrow @nogc
+        {
+            mov tmp, RAX;
         }
 
         return cast(T)tmp;

--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -2410,7 +2410,7 @@ else
         ///
         float   fabsf(float x);
         ///
-        real    fabsl(real x);        
+        real    fabsl(real x);
     }
 
     ///

--- a/src/core/sys/linux/epoll.d
+++ b/src/core/sys/linux/epoll.d
@@ -3,7 +3,7 @@
  * Available since Linux 2.6
  *
  * Copyright: Copyright Adil Baig 2012.
- * License : $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0) 
+ * License : $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Authors  : Adil Baig (github.com/adilbaig)
  */
 module core.sys.linux.epoll;
@@ -20,21 +20,21 @@ enum
     EPOLL_NONBLOCK = 0x800
 }
 
-enum 
+enum
 {
-    EPOLLIN 	= 0x001,
-    EPOLLPRI 	= 0x002,
-    EPOLLOUT 	= 0x004,
+    EPOLLIN     = 0x001,
+    EPOLLPRI    = 0x002,
+    EPOLLOUT    = 0x004,
     EPOLLRDNORM = 0x040,
     EPOLLRDBAND = 0x080,
     EPOLLWRNORM = 0x100,
     EPOLLWRBAND = 0x200,
-    EPOLLMSG 	= 0x400,
-    EPOLLERR 	= 0x008,
-    EPOLLHUP 	= 0x010,
-    EPOLLRDHUP 	= 0x2000, // since Linux 2.6.17
+    EPOLLMSG    = 0x400,
+    EPOLLERR    = 0x008,
+    EPOLLHUP    = 0x010,
+    EPOLLRDHUP  = 0x2000, // since Linux 2.6.17
     EPOLLONESHOT = 1u << 30,
-    EPOLLET 	= 1u << 31
+    EPOLLET     = 1u << 31
 }
 
 /* Valid opcodes ( "op" parameter ) to issue to epoll_ctl().  */
@@ -45,21 +45,21 @@ enum
     EPOLL_CTL_MOD = 3, // Change file descriptor epoll_event structure.
 }
 
-struct epoll_event 
+struct epoll_event
 {
     align(1):
       uint events;
       epoll_data_t data;
 };
 
-union epoll_data_t 
+union epoll_data_t
 {
     void *ptr;
     int fd;
     uint u32;
     ulong u64;
 };
- 
+
 int epoll_create (int size);
 int epoll_create1 (int flags);
 int epoll_ctl (int epfd, int op, int fd, epoll_event *event);

--- a/src/core/sys/linux/sys/xattr.d
+++ b/src/core/sys/linux/sys/xattr.d
@@ -15,8 +15,8 @@ extern (C):
 nothrow:
 
 enum {
-	XATTR_CREATE = 1, /* set value, fail if attr already exists.  */
-	XATTR_REPLACE = 2 /* set value, fail if attr does not exist.  */
+    XATTR_CREATE = 1, /* set value, fail if attr already exists.  */
+    XATTR_REPLACE = 2 /* set value, fail if attr does not exist.  */
 }
 
 enum XATTR_OS2_PREFIX = "os2.";

--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -16,7 +16,7 @@ version (Posix):
 extern (C) :
 
 version(CRuntime_Glibc) {
-    static if(__WORDSIZE == 32) 
+    static if(__WORDSIZE == 32)
     {
         version=_STATVFSBUF_F_UNUSED;
     }
@@ -31,7 +31,7 @@ version(CRuntime_Glibc) {
         fsfilcnt_t f_ffree;
         fsfilcnt_t f_favail;
         c_ulong f_fsid;
-        version(_STATVFSBUF_F_UNUSED) 
+        version(_STATVFSBUF_F_UNUSED)
         {
             int __f_unused;
         }
@@ -41,7 +41,7 @@ version(CRuntime_Glibc) {
     }
     /* Definitions for the flag in `f_flag'.  These definitions should be
       kept in sync with the definitions in <sys/mount.h>.  */
-    static if(__USE_GNU) 
+    static if(__USE_GNU)
     {
         enum FFlag
         {
@@ -60,7 +60,7 @@ version(CRuntime_Glibc) {
 
         }
     }  /* Use GNU.  */
-    else 
+    else
     { // Posix defined:
         enum FFlag
         {

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -695,7 +695,7 @@ else version (Solaris)
             ubyte __pthread_mutex_flag2;
             ubyte __pthread_mutex_ceiling;
             ushort __pthread_mutex_type;
-            ushort __pthread_mutex_magic; 
+            ushort __pthread_mutex_magic;
         }
 
         ___pthread_mutex_flags __pthread_mutex_flags;
@@ -821,7 +821,7 @@ else version (Solaris)
         ulong __pthread_barrier_cycle;
         ulong __pthread_barrier_reserved;
         pthread_mutex_t __pthread_barrier_lock;
-        pthread_cond_t __pthread_barrier_cond; 
+        pthread_cond_t __pthread_barrier_cond;
     }
 
     struct pthread_barrierattr_t

--- a/src/core/sys/posix/syslog.d
+++ b/src/core/sys/posix/syslog.d
@@ -32,7 +32,7 @@ version(CRuntime_Glibc)
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
     };
-    
+
     //OPTIONS
     enum {
         LOG_PID    = 0x01,  /* log the pid with each message */
@@ -42,7 +42,7 @@ version(CRuntime_Glibc)
         LOG_NOWAIT = 0x10,  /* don't wait for console forks: DEPRECATED */
         LOG_PERROR = 0x20,  /* log to stderr as well */
     };
-    
+
     //FACILITY
     enum {
         LOG_KERN   = (0<<3),  /* kernel messages */
@@ -57,7 +57,7 @@ version(CRuntime_Glibc)
         LOG_CRON   = (9<<3),  /* clock daemon */
         LOG_AUTHPRIV = (10<<3), /* security/authorization messages (private), */
         LOG_FTP    =  (11<<3), /* ftp daemon */
-        
+
         /* other codes through 15 reserved for system use */
         LOG_LOCAL0 = (16<<3), /* reserved for local use */
         LOG_LOCAL1 = (17<<3), /* reserved for local use */
@@ -67,13 +67,13 @@ version(CRuntime_Glibc)
         LOG_LOCAL5 = (21<<3), /* reserved for local use */
         LOG_LOCAL6 = (22<<3), /* reserved for local use */
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
-        
+
         LOG_NFACILITIES = 24,  /* current number of facilities */
     };
-    
+
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
-    
+
     void openlog (const char *, int __option, int __facility);
     int  setlogmask (int __mask);
     void syslog (int __pri, const char *__fmt, ...);
@@ -82,7 +82,7 @@ version(CRuntime_Glibc)
 else version( OSX )
 {
     //http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/osfmk/sys/syslog.h
-    
+
     //PRIORITY
     enum {
         LOG_EMERG = 0,     /* system is unusable */
@@ -94,7 +94,7 @@ else version( OSX )
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
     };
-    
+
     //OPTIONS
     enum {
         LOG_PID    = 0x01,     /* log the pid with each message */
@@ -103,7 +103,7 @@ else version( OSX )
         LOG_NDELAY = 0x08,  /* don't delay open */
         LOG_NOWAIT = 0x10,  /* don't wait for console forks: DEPRECATED */
     };
-    
+
     //FACILITY
     enum {
         LOG_KERN   = (0<<3),  /* kernel messages */
@@ -115,7 +115,7 @@ else version( OSX )
         LOG_LPR    = (6<<3),  /* line printer subsystem */
         LOG_NEWS   = (7<<3),  /* network news subsystem */
         LOG_UUCP   = (8<<3),  /* UUCP subsystem */
-        
+
         /* other codes through 15 reserved for system use */
         LOG_LOCAL0 = (16<<3), /* reserved for local use */
         LOG_LOCAL1 = (17<<3), /* reserved for local use */
@@ -125,13 +125,13 @@ else version( OSX )
         LOG_LOCAL5 = (21<<3), /* reserved for local use */
         LOG_LOCAL6 = (22<<3), /* reserved for local use */
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
-        
+
         LOG_NFACILITIES = 24,  /* current number of facilities */
     };
-    
+
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
-    
+
     void openlog (const char *, int __option, int __facility);
     int  setlogmask (int __mask);
     void syslog (int __pri, const char *__fmt, ...);
@@ -140,7 +140,7 @@ else version( OSX )
 else version( FreeBSD )
 {
     //http://fxr.watson.org/fxr/source/sys/syslog.h
-    
+
     //PRIORITY
     enum {
         LOG_EMERG = 0,     /* system is unusable */
@@ -152,7 +152,7 @@ else version( FreeBSD )
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
     };
-    
+
     //OPTIONS
     enum {
         LOG_PID    = 0x01,    /* log the pid with each message */
@@ -162,7 +162,7 @@ else version( FreeBSD )
         LOG_NOWAIT = 0x10,    /* don't wait for console forks: DEPRECATED */
         LOG_PERROR = 0x20,    /* log to stderr as well */
     };
-    
+
     //FACILITY
     enum {
         LOG_KERN   = (0<<3),  /* kernel messages */
@@ -180,7 +180,7 @@ else version( FreeBSD )
         LOG_NTP    = (12<<3), /* NTP subsystem */
         LOG_SECURITY = (13<<3), /* security subsystems (firewalling, etc.) */
         LOG_CONSOLE  = (14<<3), /* /dev/console output */
-  
+
         /* other codes through 15 reserved for system use */
         LOG_LOCAL0 = (16<<3), /* reserved for local use */
         LOG_LOCAL1 = (17<<3), /* reserved for local use */
@@ -190,13 +190,13 @@ else version( FreeBSD )
         LOG_LOCAL5 = (21<<3), /* reserved for local use */
         LOG_LOCAL6 = (22<<3), /* reserved for local use */
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
-        
+
         LOG_NFACILITIES = 24,  /* current number of facilities */
     };
-    
+
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
-    
+
     void openlog (const char *, int __option, int __facility);
     int  setlogmask (int __mask);
     void syslog (int __pri, const char *__fmt, ...);
@@ -205,7 +205,7 @@ else version( FreeBSD )
 else version( Solaris )
 {
     //http://pubs.opengroup.org/onlinepubs/007904875/basedefs/syslog.h.html
-    
+
     //PRIORITY
     enum {
         LOG_EMERG = 0,     /* system is unusable */
@@ -217,7 +217,7 @@ else version( Solaris )
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
     };
-    
+
     //OPTIONS
     enum {
         LOG_PID = 0x01,     /* log the pid with each message */
@@ -225,7 +225,7 @@ else version( Solaris )
         LOG_NDELAY = 0x08,  /* don't delay open */
         LOG_NOWAIT = 0x10,  /* don't wait for console forks: DEPRECATED */
     };
-    
+
     //FACILITY
     enum {
         LOG_KERN   = (0<<3),  /* kernel messages */
@@ -240,7 +240,7 @@ else version( Solaris )
         LOG_CRON   = (9<<3),  /* clock daemon */
         LOG_AUTHPRIV = (10<<3), /* security/authorization messages (private), */
         LOG_FTP    =  (11<<3), /* ftp daemon */
-        
+
         /* other codes through 15 reserved for system use */
         LOG_LOCAL0 = (16<<3), /* reserved for local use */
         LOG_LOCAL1 = (17<<3), /* reserved for local use */
@@ -250,13 +250,13 @@ else version( Solaris )
         LOG_LOCAL5 = (21<<3), /* reserved for local use */
         LOG_LOCAL6 = (22<<3), /* reserved for local use */
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
-        
+
         LOG_NFACILITIES = 24,  /* current number of facilities */
     };
-    
+
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
-    
+
     void openlog (const char *, int __option, int __facility);
     int  setlogmask (int __mask);
     void syslog (int __pri, const char *__fmt, ...);

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -786,7 +786,7 @@ else version( FreeBSD )
         _SC_XOPEN_XCU_VERSION              = 117,
         _SC_CPUSET_SIZE                    = 122,
         _SC_PHYS_PAGES                     = 121,
-    }     
+    }
 
     enum _SC_PAGE_SIZE = _SC_PAGESIZE;
 

--- a/src/core/sys/windows/winsock2.d
+++ b/src/core/sys/windows/winsock2.d
@@ -390,7 +390,7 @@ int FD_ISSET(SOCKET fd, const(fd_set)* set) pure @nogc
 
 
 // Adds.
-void FD_SET(SOCKET fd, fd_set* set)	pure @nogc
+void FD_SET(SOCKET fd, fd_set* set)     pure @nogc
 {
     uint c = set.fd_count;
     set.fd_array.ptr[c] = fd;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4017,7 +4017,7 @@ class Fiber
      * fibers that have terminated, as doing otherwise could result in
      * scope-dependent functionality that is not executed.
      * Stack-based classes, for example, may not be cleaned up
-     * properly if a fiber is reset before it has terminated. 
+     * properly if a fiber is reset before it has terminated.
      *
      * In:
      *  This fiber must be in state TERM or HOLD.

--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -391,7 +391,7 @@ fiber_switchContext:
  * r13 =sp : stack pointer
  * r14 =lr : link register, it contains the return address (belonging to the function which called us)
  * r15 =pc : program counter
- * 
+ *
  * For floating point registers:
  * According to AAPCS (version 2.09, section 5.1.2) only the d8-d15 registers need to be preserved
  * across method calls. This applies to all ARM FPU variants, whether they have 16 or 32 double registers

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -3343,29 +3343,29 @@ else
 debug (MEMSTOMP)
 unittest
 {
-	import core.memory;
-	auto p = cast(uint*)GC.malloc(uint.sizeof*3);
-	assert(*p == 0xF0F0F0F0);
-	p[2] = 0; // First two will be used for free list
-	GC.free(p);
-	assert(p[2] == 0xF2F2F2F2);
+    import core.memory;
+    auto p = cast(uint*)GC.malloc(uint.sizeof*3);
+    assert(*p == 0xF0F0F0F0);
+    p[2] = 0; // First two will be used for free list
+    GC.free(p);
+    assert(p[2] == 0xF2F2F2F2);
 }
 
 debug (SENTINEL)
 unittest
 {
-	import core.memory;
-	auto p = cast(ubyte*)GC.malloc(1);
-	assert(p[-1] == 0xF4);
-	assert(p[ 1] == 0xF5);
+    import core.memory;
+    auto p = cast(ubyte*)GC.malloc(1);
+    assert(p[-1] == 0xF4);
+    assert(p[ 1] == 0xF5);
 /*
-	p[1] = 0;
-	bool thrown;
-	try
-		GC.free(p);
-	catch (Error e)
-		thrown = true;
-	p[1] = 0xF5;
-	assert(thrown);
+    p[1] = 0;
+    bool thrown;
+    try
+        GC.free(p);
+    catch (Error e)
+        thrown = true;
+    p[1] = 0xF5;
+    assert(thrown);
 */
 }

--- a/src/rt/util/container/treap.d
+++ b/src/rt/util/container/treap.d
@@ -32,7 +32,7 @@ nothrow:
         rand48.defaultSeed();
     }
 
-    void insert(E element) @nogc 
+    void insert(E element) @nogc
     {
         root = insert(root, element);
     }
@@ -110,7 +110,7 @@ private:
     Node* root;
     Rand48 rand48;
 
-    Node* allocNode(E element) @nogc 
+    Node* allocNode(E element) @nogc
     {
         Node* node = cast(Node*)common.xmalloc(Node.sizeof);
         node.left = node.right = null;
@@ -119,7 +119,7 @@ private:
         return node;
     }
 
-    Node* insert(Node* node, E element) @nogc 
+    Node* insert(Node* node, E element) @nogc
     {
         if (!node)
             return allocNode(element);

--- a/src/rt/util/random.d
+++ b/src/rt/util/random.d
@@ -24,19 +24,19 @@ nothrow:
         popFront();
     }
 
-    auto opCall() @nogc 
+    auto opCall() @nogc
     {
         auto result = front;
         popFront();
         return result;
     }
 
-    @property uint front() @nogc 
+    @property uint front() @nogc
     {
         return cast(uint)(rng_state >> 16);
     }
 
-    void popFront() @nogc 
+    void popFront() @nogc
     {
         immutable ulong a = 25214903917;
         immutable ulong c = 11;


### PR DESCRIPTION
Trying not to commit bad line endings again, I added checkwhitespace to my build batch. This fails for some existing files, though.