### PR TITLE
add osmodel.mak to MANIFEST

### DIFF
--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -5,6 +5,7 @@ MANIFEST=\
 	posix.mak \
 	win32.mak \
 	win64.mak \
+	osmodel.mak \
 	project.ddoc \
 	\
 	mak\COPY \


### PR DESCRIPTION
Because nobody ever remembers to update MANIFEST when adding files, leading to files missing from the zip file.

grumble, grumble