### PR TITLE
add auto-tester specific targets

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -229,3 +229,10 @@ clean: $(addsuffix /.clean,$(ADDITIONAL_TESTS))
 
 test/%/.clean: test/%/Makefile
 	$(MAKE) -C test/$* clean
+
+.PHONY : auto-tester-build
+auto-tester-build: target
+
+.PHONY : auto-tester-test
+auto-tester-test: unittest
+

--- a/win32.mak
+++ b/win32.mak
@@ -662,3 +662,8 @@ install: druntime.zip
 clean:
 	del $(DRUNTIME) $(OBJS_TO_DELETE) $(GCSTUB)
 	rmdir /S /Q $(DOCDIR) $(IMPDIR)
+
+auto-tester-build: target
+
+auto-tester-test: unittest
+

--- a/win64.mak
+++ b/win64.mak
@@ -686,3 +686,8 @@ install: druntime.zip
 clean:
 	del $(DRUNTIME) $(OBJS_TO_DELETE) $(GCSTUB)
 	rmdir /S /Q $(DOCDIR) $(IMPDIR)
+
+auto-tester-build: target
+
+auto-tester-test: unittest
+


### PR DESCRIPTION
This gives control to the repository rather than the auto-tester.

The choice of target is based on current behavior.  For auto-tester-build, the tester isn't specifying a target, so the behavior is 'whatever is first in the makefile'.  That's 'target' for all the current makefiles.  For auto-tester-test, that's explicitly 'unittest' in the current tester build scripts.

This will need to be merged to the other branches before the tester can switch to using these new targets.