### PR TITLE
Modify TypeInfo.init to match the spec

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -286,7 +286,10 @@ class TypeInfo
     /// Return default initializer.  If the type should be initialized to all zeros,
     /// an array with a null ptr and a length equal to the type size will be returned.
     // TODO: make this a property, but may need to be renamed to diambiguate with T.init...
-    const(void)[] init() nothrow pure const @safe @nogc { return null; }
+    const(void)[] init() nothrow pure const @safe @nogc 
+    { 
+        return (cast(void *)null)[0..tsize];
+    }
 
     /// Get flags for type: 1 means GC should scan for pointers,
     /// 2 means arg of this type is passed in XMM register

--- a/src/object.d
+++ b/src/object.d
@@ -286,7 +286,7 @@ class TypeInfo
     /// Return default initializer.  If the type should be initialized to all zeros,
     /// an array with a null ptr and a length equal to the type size will be returned.
     // TODO: make this a property, but may need to be renamed to diambiguate with T.init...
-    const(void)[] init() nothrow pure const @safe @nogc 
+    const(void)[] init() nothrow pure const @nogc 
     { 
         return (cast(void *)null)[0..tsize];
     }


### PR DESCRIPTION
Per http://dlang.org/library/object/type_info.init.html

> Return default initializer. If the type should be initialized to all zeros, an array with a null ptr and a length equal to the type size will be returned.

Currently it just returns null. I figure it would be best to fix this before someone starts building dependencies on the current (apparently) incorrect behavior.

This was brought to my attention by this thread: http://forum.dlang.org/post/751411451.1109562.1434024135030.JavaMail.yahoo@mail.yahoo.com

P.S. The TODO in the comment says it should be made into a property. Is this still the plan, or should that comment be removed?