### PR TITLE
Modify TypeInfo.init to match the spec

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -285,8 +285,10 @@ class TypeInfo
 
     /// Return default initializer.  If the type should be initialized to all zeros,
     /// an array with a null ptr and a length equal to the type size will be returned.
-    // TODO: make this a property, but may need to be renamed to diambiguate with T.init...
-    const(void)[] init() nothrow pure const @safe @nogc { return null; }
+    const(void)[] init() nothrow pure const @trusted @nogc 
+    {
+        return (cast(void *)null)[0..tsize];
+    }
 
     /// Get flags for type: 1 means GC should scan for pointers,
     /// 2 means arg of this type is passed in XMM register


### PR DESCRIPTION
Per http://dlang.org/library/object/type_info.init.html (or the comment in the source):

> Return default initializer. If the type should be initialized to all zeros, an array with a null ptr and a length equal to the type size will be returned.

Currently it just returns null. I figure it would be best to fix this before someone starts building dependencies on the current (apparently) incorrect behavior.

This was brought to my attention by this thread: http://forum.dlang.org/post/751411451.1109562.1434024135030.JavaMail.yahoo@mail.yahoo.com

Other Notes:
* I also removed the TODO to make it a property, as I don't think that belongs in production code.  If it should be done, then whoever wrote that should have done it.
* Some seem to favor just updating the documentation and leaving the current implementation.  I'm not necessarily against that, but that seems like more of a cop out than due diligence.  Also, I'm not sure, but I think if we do a documentation fix, then [this code in DMD](https://github.com/D-Programming-Language/dmd/blob/master/src/typinf.c#L458) will also need to change.
* It was mentioned that the call to virtual function `tsize` should be avoided because it could negatively affect the derived classes.  I think that that is a problem for the derived classes to solve.
* Also, it was mentioned that this implementation should be deferred to derived classes.  I actually started down that path, but it seems like I was just duplicating the same implementation over and over again, and the code started to smell.

See Also:
* [Bug 2990](https://issues.dlang.org/show_bug.cgi?id=2990)
* https://github.com/D-Programming-Language/druntime/pull/1305

Despite my opinions, I'd be happy to change this pull request to whatever implementation the consensus prefers.  Please advise me so I can get it done right and be done with it.