### PR TITLE
Modify TypeInfo.init to match the spec - Take 2 - Derived class implementation

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -285,8 +285,7 @@ class TypeInfo
 
     /// Return default initializer.  If the type should be initialized to all zeros,
     /// an array with a null ptr and a length equal to the type size will be returned.
-    // TODO: make this a property, but may need to be renamed to diambiguate with T.init...
-    const(void)[] init() nothrow pure const @safe @nogc { return null; }
+    abstract const(void)[] init() nothrow pure const @safe @nogc;
 
     /// Get flags for type: 1 means GC should scan for pointers,
     /// 2 means arg of this type is passed in XMM register
@@ -338,7 +337,7 @@ class TypeInfo_Typedef : TypeInfo
 
     override @property inout(TypeInfo) next() nothrow pure inout { return base.next; }
     override @property uint flags() nothrow pure const { return base.flags; }
-    override const(void)[] init() nothrow pure const @safe { return m_init.length ? m_init : base.init(); }
+    override const(void)[] init() const { return m_init.length ? m_init : base.init(); }
 
     override @property size_t talign() nothrow pure const { return base.talign; }
 
@@ -464,6 +463,11 @@ class TypeInfo_Array : TypeInfo
     override @property size_t tsize() nothrow pure const
     {
         return (void[]).sizeof;
+    }
+
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. (void[]).sizeof];
     }
 
     override void swap(void* p1, void* p2) const

--- a/src/rt/typeinfo/ti_C.d
+++ b/src/rt/typeinfo/ti_C.d
@@ -63,6 +63,11 @@ class TypeInfo_C : TypeInfo
         return Object.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. Object.sizeof];
+    }
+
     override @property uint flags() nothrow pure
     {
         return 1;

--- a/src/rt/typeinfo/ti_byte.d
+++ b/src/rt/typeinfo/ti_byte.d
@@ -44,6 +44,11 @@ class TypeInfo_g : TypeInfo
         return byte.sizeof;
     }
 
+    override const(void)[] init() @trusted
+    {
+        return (cast(void *)null)[0 .. byte.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         byte t;

--- a/src/rt/typeinfo/ti_cent.d
+++ b/src/rt/typeinfo/ti_cent.d
@@ -52,6 +52,11 @@ class TypeInfo_zi : TypeInfo
         return cent.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. cent.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         cent t;

--- a/src/rt/typeinfo/ti_char.d
+++ b/src/rt/typeinfo/ti_char.d
@@ -53,10 +53,10 @@ class TypeInfo_a : TypeInfo
         *cast(char *)p2 = t;
     }
 
-    override const(void)[] init() nothrow pure
+    override const(void)[] init() const @trusted
     {
         static immutable char c;
 
-        return (cast(char *)&c)[0 .. 1];
+        return (&c)[0 .. 1];
     }
 }

--- a/src/rt/typeinfo/ti_dchar.d
+++ b/src/rt/typeinfo/ti_dchar.d
@@ -53,10 +53,10 @@ class TypeInfo_w : TypeInfo
         *cast(dchar *)p2 = t;
     }
 
-    override const(void)[] init() nothrow pure
+    override const(void)[] init() const @trusted
     {
         static immutable dchar c;
 
-        return (cast(dchar *)&c)[0 .. 1];
+        return (&c)[0 .. 1];
     }
 }

--- a/src/rt/typeinfo/ti_delegate.d
+++ b/src/rt/typeinfo/ti_delegate.d
@@ -50,6 +50,13 @@ class TypeInfo_D : TypeInfo
         *cast(dg *)p2 = t;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        static immutable dg d;
+
+        return (cast(void *)null)[0 .. dg.sizeof];
+    }
+
     override @property uint flags() nothrow pure
     {
         return 1;

--- a/src/rt/typeinfo/ti_int.d
+++ b/src/rt/typeinfo/ti_int.d
@@ -48,6 +48,11 @@ class TypeInfo_i : TypeInfo
         return int.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. int.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         int t;

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -50,6 +50,11 @@ class TypeInfo_l : TypeInfo
         return long.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. long.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         long t;

--- a/src/rt/typeinfo/ti_ptr.d
+++ b/src/rt/typeinfo/ti_ptr.d
@@ -48,6 +48,11 @@ class TypeInfo_P : TypeInfo
         return (void*).sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. (void*).sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         void* tmp = *cast(void**)p1;

--- a/src/rt/typeinfo/ti_short.d
+++ b/src/rt/typeinfo/ti_short.d
@@ -44,6 +44,11 @@ class TypeInfo_s : TypeInfo
         return short.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. short.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         short t;

--- a/src/rt/typeinfo/ti_ubyte.d
+++ b/src/rt/typeinfo/ti_ubyte.d
@@ -44,6 +44,11 @@ class TypeInfo_h : TypeInfo
         return ubyte.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. ubyte.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         ubyte t;

--- a/src/rt/typeinfo/ti_ucent.d
+++ b/src/rt/typeinfo/ti_ucent.d
@@ -52,6 +52,11 @@ class TypeInfo_zk : TypeInfo
         return ucent.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. ucent.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         ucent t;

--- a/src/rt/typeinfo/ti_uint.d
+++ b/src/rt/typeinfo/ti_uint.d
@@ -48,6 +48,11 @@ class TypeInfo_k : TypeInfo
         return uint.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. uint.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         int t;

--- a/src/rt/typeinfo/ti_ulong.d
+++ b/src/rt/typeinfo/ti_ulong.d
@@ -50,6 +50,11 @@ class TypeInfo_m : TypeInfo
         return ulong.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. ulong.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         ulong t;

--- a/src/rt/typeinfo/ti_ushort.d
+++ b/src/rt/typeinfo/ti_ushort.d
@@ -44,6 +44,11 @@ class TypeInfo_t : TypeInfo
         return ushort.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. ushort.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         ushort t;

--- a/src/rt/typeinfo/ti_void.d
+++ b/src/rt/typeinfo/ti_void.d
@@ -44,6 +44,11 @@ class TypeInfo_v : TypeInfo
         return void.sizeof;
     }
 
+    override const(void)[] init() const @trusted
+    {
+        return (cast(void *)null)[0 .. void.sizeof];
+    }
+
     override void swap(void *p1, void *p2)
     {
         byte t;

--- a/src/rt/typeinfo/ti_wchar.d
+++ b/src/rt/typeinfo/ti_wchar.d
@@ -53,10 +53,10 @@ class TypeInfo_u : TypeInfo
         *cast(wchar *)p2 = t;
     }
 
-    override const(void)[] init()
+    override const(void)[] init() const @trusted
     {
         static immutable wchar c;
 
-        return (cast(wchar *)&c)[0 .. 1];
+        return (&c)[0 .. 1];
     }
 }


### PR DESCRIPTION
This is an alternative implementation for https://github.com/D-Programming-Language/druntime/pull/1306

It makes `TypeInfo.init()` abstract, and defers implementation to the derived classes.

**Motivation** (copied from https://github.com/D-Programming-Language/druntime/pull/1306 for convenience)
Per http://dlang.org/library/object/type_info.init.html (or the comment in the source):

>Return default initializer. If the type should be initialized to all zeros, an array with a null ptr and a length equal to the type size will be returned.

Currently it just returns null. I figure it would be best to fix this before someone starts building dependencies on the current (apparently) incorrect behavior.

This was brought to my attention by this thread: http://forum.dlang.org/post/751411451.1109562.1434024135030.JavaMail.yahoo@mail.yahoo.com