### PR TITLE
fixup Issue 14746

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2226,18 +2226,10 @@ unittest
 private void _destructRecurse(S)(ref S s)
     if (is(S == struct))
 {
-    import core.internal.traits : hasElaborateDestructor;
-
-    static if (__traits(hasMember, S, "__dtor") &&
+    static if (__traits(hasMember, S, "__xdtor") &&
                // Bugzilla 14746: Check that it's the exact member of S.
-               __traits(isSame, S, __traits(parent, s.__dtor)))
-        s.__dtor();
-
-    foreach_reverse (ref field; s.tupleof)
-    {
-        static if (hasElaborateDestructor!(typeof(field)))
-            _destructRecurse(field);
-    }
+               __traits(isSame, S, __traits(parent, s.__xdtor)))
+        s.__xdtor();
 }
 
 private void _destructRecurse(E, size_t n)(ref E[n] arr)
@@ -2251,34 +2243,14 @@ private void _destructRecurse(E, size_t n)(ref E[n] arr)
     }
 }
 
-private string _genFieldPostblit(S)()
-{
-    import core.internal.traits : hasElaborateCopyConstructor;
-
-    string code;
-    foreach(i, FieldType; typeof(S.init.tupleof))
-    {
-        static if(hasElaborateCopyConstructor!FieldType)
-        {
-            code ~= `
-                _postblitRecurse(s.tupleof[` ~ i.stringof ~ `]);
-                scope(failure) _destructRecurse(s.tupleof[` ~ i.stringof ~ `]);
-            `;
-        }
-    }
-    return code;
-}
-
 // Public and explicitly undocumented
 void _postblitRecurse(S)(ref S s)
     if (is(S == struct))
 {
-    mixin(_genFieldPostblit!S());
-
-    static if (__traits(hasMember, S, "__postblit") &&
+    static if (__traits(hasMember, S, "__xpostblit") &&
                // Bugzilla 14746: Check that it's the exact member of S.
-               __traits(isSame, S, __traits(parent, s.__postblit)))
-        s.__postblit();
+               __traits(isSame, S, __traits(parent, s.__xpostblit)))
+        s.__xpostblit();
 }
 
 // Ditto


### PR DESCRIPTION
- also fix _postblitRecurse
- replace recursive templates with _xdtor and _xpostblit

[Issue 14746 – [REG2.068a] Behavior change with struct destructor and alias this](https://issues.dlang.org/show_bug.cgi?id=14746)