### PR TITLE
make checkwhitespace runnable on windows

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -207,12 +207,13 @@ test/%/.run: test/%/Makefile
 		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) QUIET=$(QUIET) LINKDL=$(LINKDL)
 
 #################### test for undesired white spaces ##########################
-MAKEFILES = $(filter mak/% %.mak,$(MANIFEST))
-NOT_MAKEFILES = $(filter-out $(MAKEFILES),$(MANIFEST))
+CWS_MAKEFILES = $(filter mak/% %.mak,$(MANIFEST))
+NOT_MAKEFILES = $(filter-out $(CWS_MAKEFILES),$(MANIFEST))
+GREP = grep
 
 checkwhitespace:
-	grep -n -P "([ \t]$$|\r)" $(MAKEFILES) ; test "$$?" -ne 0
-	grep -n -P "( $$|\r\t)" $(NOT_MAKEFILES) ; test "$$?" -ne 0
+	$(GREP) -n -U -P "([ \t]$$|\r)" $(CWS_MAKEFILES) ; test "$$?" -ne 0
+	$(GREP) -n -U -P "( $$|\r\t)" $(NOT_MAKEFILES) ; test "$$?" -ne 0
 
 detab:
 	detab $(MANIFEST)

--- a/posix.mak
+++ b/posix.mak
@@ -212,8 +212,11 @@ NOT_MAKEFILES = $(filter-out $(CWS_MAKEFILES),$(MANIFEST))
 GREP = grep
 
 checkwhitespace:
+# restrict to linux, other platforms don't have a version of grep that supports -P
+ifeq (linux,$(OS))
 	$(GREP) -n -U -P "([ \t]$$|\r)" $(CWS_MAKEFILES) ; test "$$?" -ne 0
 	$(GREP) -n -U -P "( $$|\r|\t)" $(NOT_MAKEFILES) ; test "$$?" -ne 0
+endif
 
 detab:
 	detab $(MANIFEST)

--- a/posix.mak
+++ b/posix.mak
@@ -213,7 +213,7 @@ GREP = grep
 
 checkwhitespace:
 	$(GREP) -n -U -P "([ \t]$$|\r)" $(CWS_MAKEFILES) ; test "$$?" -ne 0
-	$(GREP) -n -U -P "( $$|\r\t)" $(NOT_MAKEFILES) ; test "$$?" -ne 0
+	$(GREP) -n -U -P "( $$|\r|\t)" $(NOT_MAKEFILES) ; test "$$?" -ne 0
 
 detab:
 	detab $(MANIFEST)


### PR DESCRIPTION
- do not abuse MAKEFILES, it is a predefined variable in some versions of make
- make grep overloadable (grep installed with git on windows is too old to support -P)
- add -U to the command line, otherwise \r is not detected when run under windows