### PR TITLE
fix Issue 11414 - druntime should run debug unittest

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -241,7 +241,7 @@ $(ROOT)/unittest/% : $(ROOT)/unittest/test_runner
 # succeeded, render the file new again
 	@touch $@
 
-test/init_fini/.run test/exceptions/.run: $(DRUNTIME)
+$(addsuffix /.run,$(filter-out test/shared,$(ADDITIONAL_TESTS))): $(DRUNTIME)
 test/shared/.run: $(DRUNTIMESO)
 
 test/%/.run: test/%/Makefile

--- a/posix.mak
+++ b/posix.mak
@@ -273,9 +273,6 @@ druntime.zip: $(MANIFEST) $(IMPORTS)
 install: target
 	mkdir -p $(INSTALL_DIR)/src/druntime/import
 	cp -r import/* $(INSTALL_DIR)/src/druntime/import/
-	$(eval lib_dir=$(if $(filter $(OS),osx), lib, lib$(MODEL)))
-	mkdir -p $(INSTALL_DIR)/$(OS)/$(lib_dir)
-	cp -r lib/* $(INSTALL_DIR)/$(OS)/$(lib_dir)/
 	cp LICENSE $(INSTALL_DIR)/druntime-LICENSE.txt
 
 clean: $(addsuffix /.clean,$(ADDITIONAL_TESTS))

--- a/posix.mak
+++ b/posix.mak
@@ -132,7 +132,7 @@ $(DOCDIR)/core_sync_%.html : src/core/sync/%.d
 import: $(IMPORTS)
 
 $(IMPDIR)/core/sync/%.di : src/core/sync/%.d
-	@mkdir -p `dirname $@`
+	@mkdir -p $(dir $@)
 	$(DMD) -conf= -c -o- -Isrc -Iimport -Hf$@ $<
 
 ######################## Header .di file copy ##############################
@@ -140,30 +140,30 @@ $(IMPDIR)/core/sync/%.di : src/core/sync/%.d
 copy: $(COPY)
 
 $(IMPDIR)/object.d : src/object.d
-	@mkdir -p `dirname $@`
+	@mkdir -p $(dir $@)
 	@rm -f $(IMPDIR)/object.di
 	cp $< $@
 
 $(IMPDIR)/%.di : src/%.di
-	@mkdir -p `dirname $@`
+	@mkdir -p $(dir $@)
 	cp $< $@
 
 $(IMPDIR)/%.d : src/%.d
-	@mkdir -p `dirname $@`
+	@mkdir -p $(dir $@)
 	cp $< $@
 
 ################### C/ASM Targets ############################
 
 $(ROOT)/%.o : src/rt/%.c
-	@mkdir -p `dirname $@`
+	@mkdir -p $(dir $@)
 	$(CC) -c $(CFLAGS) $< -o$@
 
 $(ROOT)/errno_c.o : src/core/stdc/errno.c
-	@mkdir -p `dirname $@`
+	@mkdir -p $(dir $@)
 	$(CC) -c $(CFLAGS) $< -o$@
 
 $(ROOT)/threadasm.o : src/core/threadasm.S
-	@mkdir -p $(OBJDIR)
+	@mkdir -p $(dir $@)
 	$(CC) -c $(CFLAGS) $< -o$@
 
 ######################## Create a shared library ##############################

--- a/test/common.mak
+++ b/test/common.mak
@@ -1,0 +1,28 @@
+# set from top makefile
+OS:=
+MODEL:=
+BUILD:=
+DMD:=
+DRUNTIME:=
+DRUNTIMESO:=
+QUIET:=
+LINKDL:=
+LDL:=$(subst -L,,$(LINKDL)) # -ldl
+
+SRC:=src
+ROOT:=./generated/$(OS)/$(BUILD)/$(MODEL)
+
+ifneq (default,$(MODEL))
+	MODEL_FLAG:=-m$(MODEL)
+endif
+CFLAGS:=$(MODEL_FLAG) -Wall
+DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib=
+# LINK_SHARED may be set by importing makefile
+DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO),-L$(DRUNTIME))
+ifeq ($(BUILD),debug)
+	DFLAGS += -g -debug
+	CFLAGS += -g
+else
+	DFLAGS += -O -release
+	CFLAGS += -O3
+endif

--- a/test/coverage/Makefile
+++ b/test/coverage/Makefile
@@ -1,24 +1,11 @@
-# set from top makefile
-OS:=
-MODEL:=
-DMD:=
-DRUNTIME:=
-DRUNTIMESO:=
-QUIET:=
-LINKDL:=
+include ../common.mak
 
-SRC:=src
-ROOT:=./obj/$(OS)/$(MODEL)
+DFLAGS+=-cov
+
 NORMAL_TESTS:=$(addprefix $(ROOT)/,$(addsuffix .done,basic))
 MERGE_TESTS:=$(addprefix $(ROOT)/,$(addsuffix .done,merge merge_true))
 
 DIFF:=diff
-
-ifneq (default,$(MODEL))
-	MODEL_FLAG:=-m$(MODEL)
-endif
-CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -L$(DRUNTIME) -defaultlib= -debuglib= -cov
 
 .PHONY: all clean
 all: $(NORMAL_TESTS) $(MERGE_TESTS)
@@ -42,4 +29,4 @@ $(ROOT)/%: $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$(ROOT)/$* $<
 
 clean:
-	rm -rf obj *.lst
+	rm -rf $(ROOT) *.lst

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,21 +1,6 @@
-# set from top makefile
-OS:=
-MODEL:=
-DMD:=
-DRUNTIME:=
-DRUNTIMESO:=
-QUIET:=
-LINKDL:=
+include ../common.mak
 
-SRC:=src
-ROOT:=./obj/$(OS)/$(MODEL)
 TESTS:=stderr_msg unittest_assert
-
-ifneq (default,$(MODEL))
-	MODEL_FLAG:=-m$(MODEL)
-endif
-CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -L$(DRUNTIME) -defaultlib= -debuglib=
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -40,4 +25,4 @@ $(ROOT)/%: $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 
 clean:
-	rm -rf obj
+	rm -rf $(ROOT)

--- a/test/init_fini/Makefile
+++ b/test/init_fini/Makefile
@@ -1,21 +1,6 @@
-# set from top makefile
-OS:=
-MODEL:=
-DMD:=
-DRUNTIME:=
-DRUNTIMESO:=
-QUIET:=
-LINKDL:=
+include ../common.mak
 
-SRC:=src
-ROOT:=./obj/$(OS)/$(MODEL)
 TESTS:=thread_join runtime_args
-
-ifneq (default,$(MODEL))
-	MODEL_FLAG:=-m$(MODEL)
-endif
-CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -L$(DRUNTIME) -defaultlib= -debuglib=
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -29,4 +14,4 @@ $(ROOT)/%: $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 
 clean:
-	rm -rf obj
+	rm -rf $(ROOT)

--- a/test/shared/Makefile
+++ b/test/shared/Makefile
@@ -1,23 +1,9 @@
-# set from top makefile
-OS:=
-MODEL:=
-DMD:=
-DRUNTIME:=
-DRUNTIMESO:=
-QUIET:=
-LINKDL:= # -L-ldl
-LDL:=$(subst -L,,$(LINKDL)) # -ldl
+LINK_SHARED:=1
 
-SRC:=src
-ROOT:=./obj/$(OS)/$(MODEL)
+include ../common.mak
+
 TESTS:=link load linkD linkDR loadDR host finalize
 TESTS+=link_linkdep load_linkdep link_loaddep load_loaddep load_13414
-
-ifneq (default,$(MODEL))
-	MODEL_FLAG:=-m$(MODEL)
-endif
-CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -L$(DRUNTIMESO) -defaultlib= -debuglib=
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -72,4 +58,4 @@ $(ROOT)/%.so: $(SRC)/%.d $(DRUNTIMESO)
 	$(QUIET)$(DMD) -fPIC -shared $(DFLAGS) -of$@ $< $(LINKDL)
 
 clean:
-	rm -rf obj
+	rm -rf $(ROOT)


### PR DESCRIPTION
- change druntime's makefile structure to match phobos
- define ROOT folder as generated/$(OS)/$(BUILD)/$(MODEL)
- unittest rule recursively invokes debug/release unittest
- factor out common.mak from test/*/Makefile and test debug/release

[Issue 11414 – druntime should run debug unittest](https://issues.dlang.org/show_bug.cgi?id=11414)