### PR TITLE
Make use of invalid MemoryOrder semantics a compile-time error

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -105,7 +105,8 @@ version( CoreDdoc )
     /**
      * Loads 'val' from memory and returns it.  The memory barrier specified
      * by 'ms' is applied to the operation, which is fully sequenced by
-     * default.
+     * default.  Valid memory orders are MemoryOrder.raw, MemoryOrder.acq,
+     * and MemoryOrder.seq.
      *
      * Params:
      *  val = The target variable.
@@ -122,6 +123,8 @@ version( CoreDdoc )
     /**
      * Writes 'newval' into 'val'.  The memory barrier specified by 'ms' is
      * applied to the operation, which is fully sequenced by default.
+     * Valid memory orders are MemoryOrder.raw, MemoryOrder.rel, and
+     * MemoryOrder.seq.
      *
      * Params:
      *  val    = The target variable.
@@ -371,26 +374,11 @@ else version( AsmX86_32 )
 
     private
     {
-        template isHoistOp(MemoryOrder ms)
-        {
-            enum bool isHoistOp = ms == MemoryOrder.acq ||
-                                  ms == MemoryOrder.seq;
-        }
-
-
-        template isSinkOp(MemoryOrder ms)
-        {
-            enum bool isSinkOp = ms == MemoryOrder.rel ||
-                                 ms == MemoryOrder.seq;
-        }
-
-
         // NOTE: x86 loads implicitly have acquire semantics so a memory
         //       barrier is only necessary on releases.
         template needsLoadBarrier( MemoryOrder ms )
         {
-            enum bool needsLoadBarrier = ms == MemoryOrder.seq ||
-                                               isSinkOp!(ms);
+            enum bool needsLoadBarrier = ms == MemoryOrder.seq;
         }
 
 
@@ -398,8 +386,7 @@ else version( AsmX86_32 )
         //       barrier is only necessary on acquires.
         template needsStoreBarrier( MemoryOrder ms )
         {
-            enum bool needsStoreBarrier = ms == MemoryOrder.seq ||
-                                                isHoistOp!(ms);
+            enum bool needsStoreBarrier = ms == MemoryOrder.seq;
         }
     }
 
@@ -407,11 +394,10 @@ else version( AsmX86_32 )
     HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) pure nothrow @nogc
     if(!__traits(isFloating, T))
     {
-        static if (!__traits(isPOD, T))
-        {
-            static assert( false, "argument to atomicLoad() must be POD" );
-        }
-        else static if( T.sizeof == byte.sizeof )
+        static assert( ms != MemoryOrder.rel, "invalid MemoryOrder for atomicLoad()" );
+        static assert( __traits(isPOD, T), "argument to atomicLoad() must be POD" );
+
+        static if( T.sizeof == byte.sizeof )
         {
             //////////////////////////////////////////////////////////////////
             // 1 Byte Load
@@ -519,6 +505,9 @@ else version( AsmX86_32 )
     void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V1)( ref shared T val, V1 newval ) pure nothrow @nogc
         if( __traits( compiles, { val = newval; } ) )
     {
+        static assert( ms != MemoryOrder.acq, "invalid MemoryOrder for atomicStore()" );
+        static assert( __traits(isPOD, T), "argument to atomicStore() must be POD" );
+
         static if( T.sizeof == byte.sizeof )
         {
             //////////////////////////////////////////////////////////////////
@@ -932,26 +921,11 @@ else version( AsmX86_64 )
 
     private
     {
-        template isHoistOp(MemoryOrder ms)
-        {
-            enum bool isHoistOp = ms == MemoryOrder.acq ||
-                                  ms == MemoryOrder.seq;
-        }
-
-
-        template isSinkOp(MemoryOrder ms)
-        {
-            enum bool isSinkOp = ms == MemoryOrder.rel ||
-                                 ms == MemoryOrder.seq;
-        }
-
-
         // NOTE: x86 loads implicitly have acquire semantics so a memory
         //       barrier is only necessary on releases.
         template needsLoadBarrier( MemoryOrder ms )
         {
-            enum bool needsLoadBarrier = ms == MemoryOrder.seq ||
-                                               isSinkOp!(ms);
+            enum bool needsLoadBarrier = ms == MemoryOrder.seq;
         }
 
 
@@ -959,14 +933,17 @@ else version( AsmX86_64 )
         //       barrier is only necessary on acquires.
         template needsStoreBarrier( MemoryOrder ms )
         {
-            enum bool needsStoreBarrier = ms == MemoryOrder.seq ||
-                                                isHoistOp!(ms);
+            enum bool needsStoreBarrier = ms == MemoryOrder.seq;
         }
     }
 
 
     HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) pure nothrow @nogc
-    if(!__traits(isFloating, T)) {
+    if(!__traits(isFloating, T))
+    {
+        static assert( ms != MemoryOrder.rel, "invalid MemoryOrder for atomicLoad()" );
+        static assert( __traits(isPOD, T), "argument to atomicLoad() must be POD" );
+
         static if( T.sizeof == byte.sizeof )
         {
             //////////////////////////////////////////////////////////////////
@@ -1123,6 +1100,9 @@ else version( AsmX86_64 )
     void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V1)( ref shared T val, V1 newval ) pure nothrow @nogc
         if( __traits( compiles, { val = newval; } ) )
     {
+        static assert( ms != MemoryOrder.acq, "invalid MemoryOrder for atomicStore()" );
+        static assert( __traits(isPOD, T), "argument to atomicStore() must be POD" );
+
         static if( T.sizeof == byte.sizeof )
         {
             //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Also removes private ``isHoistOp`` and ``isSinkOp`` templates.

@MartinNowak - we might be able to do away with the ``cmpxchg`` entirely given that load/stores on x86 should always have the desired semantics.