### PR TITLE
[REG2.066] Issue 14626 - byValue doesn't work with inout AA

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1871,6 +1871,36 @@ auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
     return (*aa).byValue();
 }
 
+auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc @property
+{
+    static struct Result
+    {
+        AARange r;
+
+    pure nothrow @nogc:
+        @property bool empty() { return _aaRangeEmpty(r); }
+        @property auto front() @trusted
+        {
+            static struct Pair
+            {
+                // We save the pointers here so that the Pair we return
+                // won't mutate when Result.popFront is called afterwards.
+                private Key* keyp;
+                private Value* valp;
+
+                @property ref inout(Key) key() inout { return *keyp; }
+                @property ref inout(Value) value() inout { return *valp; }
+            }
+            return Pair(cast(Key*)_aaRangeFrontKey(r),
+                        cast(Value*)_aaRangeFrontValue(r));
+        }
+        void popFront() { _aaRangePopFront(r); }
+        @property Result save() { return this; }
+    }
+
+    return Result(_aaRange(cast(void*)aa));
+}
+
 Key[] keys(T : Value[Key], Value, Key)(T aa) @property
 {
     auto a = cast(void[])_aaKeys(cast(inout(void)*)aa, Key.sizeof, typeid(Key[]));
@@ -1922,36 +1952,6 @@ unittest
     auto keys = aa2.keys;
     assert(keys.length == 1);
     assert(T.count == 2);
-}
-
-auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc @property
-{
-    static struct Result
-    {
-        AARange r;
-
-      pure nothrow @nogc:
-        @property bool empty() { return _aaRangeEmpty(r); }
-        @property auto front() @trusted
-        {
-            static struct Pair
-            {
-                // We save the pointers here so that the Pair we return
-                // won't mutate when Result.popFront is called afterwards.
-                private Key* keyp;
-                private Value* valp;
-
-                @property ref inout(Key) key() inout { return *keyp; }
-                @property ref inout(Value) value() inout { return *valp; }
-            }
-            return Pair(cast(Key*)_aaRangeFrontKey(r),
-                        cast(Value*)_aaRangeFrontValue(r));
-        }
-        void popFront() { _aaRangePopFront(r); }
-        @property Result save() { return this; }
-    }
-
-    return Result(_aaRange(cast(void*)aa));
 }
 
 inout(V) get(K, V)(inout(V[K]) aa, K key, lazy inout(V) defaultValue)

--- a/src/object.d
+++ b/src/object.d
@@ -1871,7 +1871,7 @@ auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
     return (*aa).byValue();
 }
 
-auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc @property
+auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
@@ -1899,6 +1899,11 @@ auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc @property
     }
 
     return Result(_aaRange(cast(void*)aa));
+}
+
+auto byKeyValue(T : Value[Key], Value, Key)(T* aa) pure nothrow @nogc
+{
+    return (*aa).byKeyValue();
 }
 
 Key[] keys(T : Value[Key], Value, Key)(T aa) @property

--- a/src/object.d
+++ b/src/object.d
@@ -1829,7 +1829,7 @@ V[K] dup(T : V[K], K, V)(T* aa)
     return (*aa).dup;
 }
 
-auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
+auto byKey(T : V[K], K, V)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
@@ -1837,7 +1837,7 @@ auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 
     pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
-        @property ref Key front() { return *cast(Key*)_aaRangeFrontKey(r); }
+        @property ref K front() { return *cast(K*)_aaRangeFrontKey(r); }
         void popFront() { _aaRangePopFront(r); }
         @property Result save() { return this; }
     }
@@ -1845,12 +1845,12 @@ auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byKey(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
+auto byKey(T : V[K], K, V)(T* aa) pure nothrow @nogc
 {
     return (*aa).byKey();
 }
 
-auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
+auto byValue(T : V[K], K, V)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
@@ -1858,7 +1858,7 @@ auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 
     pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
-        @property ref Value front() { return *cast(Value*)_aaRangeFrontValue(r); }
+        @property ref V front() { return *cast(V*)_aaRangeFrontValue(r); }
         void popFront() { _aaRangePopFront(r); }
         @property Result save() { return this; }
     }
@@ -1866,12 +1866,12 @@ auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
+auto byValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
 {
     return (*aa).byValue();
 }
 
-auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
+auto byKeyValue(T : V[K], K, V)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
@@ -1885,14 +1885,14 @@ auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
             {
                 // We save the pointers here so that the Pair we return
                 // won't mutate when Result.popFront is called afterwards.
-                private Key* keyp;
-                private Value* valp;
+                private K* keyp;
+                private V* valp;
 
-                @property ref inout(Key) key() inout { return *keyp; }
-                @property ref inout(Value) value() inout { return *valp; }
+                @property ref inout(K) key() inout { return *keyp; }
+                @property ref inout(V) value() inout { return *valp; }
             }
-            return Pair(cast(Key*)_aaRangeFrontKey(r),
-                        cast(Value*)_aaRangeFrontValue(r));
+            return Pair(cast(K*)_aaRangeFrontKey(r),
+                        cast(V*)_aaRangeFrontValue(r));
         }
         void popFront() { _aaRangePopFront(r); }
         @property Result save() { return this; }
@@ -1901,7 +1901,7 @@ auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byKeyValue(T : Value[Key], Value, Key)(T* aa) pure nothrow @nogc
+auto byKeyValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
 {
     return (*aa).byKeyValue();
 }

--- a/src/object.d
+++ b/src/object.d
@@ -1831,13 +1831,15 @@ V[K] dup(T : V[K], K, V)(T* aa)
 
 auto byKey(T : V[K], K, V)(T aa) pure nothrow @nogc
 {
+    import core.internal.traits : substInout;
+
     static struct Result
     {
         AARange r;
 
     pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
-        @property ref K front() { return *cast(K*)_aaRangeFrontKey(r); }
+        @property ref front() { return *cast(substInout!K*)_aaRangeFrontKey(r); }
         void popFront() { _aaRangePopFront(r); }
         @property Result save() { return this; }
     }
@@ -1852,13 +1854,15 @@ auto byKey(T : V[K], K, V)(T* aa) pure nothrow @nogc
 
 auto byValue(T : V[K], K, V)(T aa) pure nothrow @nogc
 {
+    import core.internal.traits : substInout;
+
     static struct Result
     {
         AARange r;
 
     pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
-        @property ref V front() { return *cast(V*)_aaRangeFrontValue(r); }
+        @property ref front() { return *cast(substInout!V*)_aaRangeFrontValue(r); }
         void popFront() { _aaRangePopFront(r); }
         @property Result save() { return this; }
     }
@@ -1873,6 +1877,8 @@ auto byValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
 
 auto byKeyValue(T : V[K], K, V)(T aa) pure nothrow @nogc
 {
+    import core.internal.traits : substInout;
+
     static struct Result
     {
         AARange r;
@@ -1885,14 +1891,14 @@ auto byKeyValue(T : V[K], K, V)(T aa) pure nothrow @nogc
             {
                 // We save the pointers here so that the Pair we return
                 // won't mutate when Result.popFront is called afterwards.
-                private K* keyp;
-                private V* valp;
+                private void* keyp;
+                private void* valp;
 
-                @property ref inout(K) key() inout { return *keyp; }
-                @property ref inout(V) value() inout { return *valp; }
+                @property ref key() inout { return *cast(substInout!K*)keyp; }
+                @property ref value() inout { return *cast(substInout!V*)valp; }
             }
-            return Pair(cast(K*)_aaRangeFrontKey(r),
-                        cast(V*)_aaRangeFrontValue(r));
+            return Pair(_aaRangeFrontKey(r),
+                        _aaRangeFrontValue(r));
         }
         void popFront() { _aaRangePopFront(r); }
         @property Result save() { return this; }
@@ -2232,6 +2238,36 @@ unittest
         auto k = t.key;
         auto v = t.value;
     }
+}
+
+unittest
+{
+    // test for bug 14626
+    static struct S
+    {
+        string[string] aa;
+        inout(string) key() inout { return aa.byKey().front; }
+        inout(string) val() inout { return aa.byValue().front; }
+        auto keyval() inout { return aa.byKeyValue().front; }
+    }
+
+    S s = S(["a":"b"]);
+    assert(s.key() == "a");
+    assert(s.val() == "b");
+    assert(s.keyval().key == "a");
+    assert(s.keyval().value == "b");
+
+    void testInoutKeyVal(inout(string) key)
+    {
+        inout(string)[typeof(key)] aa;
+
+        foreach (i; aa.byKey()) {}
+        foreach (i; aa.byValue()) {}
+        foreach (i; aa.byKeyValue()) {}
+    }
+
+    const int[int] caa;
+    static assert(is(typeof(caa.byValue().front) == const int));
 }
 
 private void _destructRecurse(S)(ref S s)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14626

Until 2.065, compiler had substituted all `inout` qualifiers in the `Key` and `Value` types to `const`, then those had passed to the template struct `AssociativeArray`.

https://github.com/D-Programming-Language/dmd/blob/v2.065.0/src/mtype.c#L4897

This change emulates that.

---

Additionally add an overload of `bykeyValue` function for AA pointer types.