### PR TITLE
[REG2.066] Issue 14626 - byValue doesn't work with inout AA

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1865,7 +1865,7 @@ auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
     return (*aa).byValue();
 }
 
-auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc @property
+auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
@@ -1893,6 +1893,11 @@ auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc @property
     }
 
     return Result(_aaRange(cast(void*)aa));
+}
+
+auto byKeyValue(T : Value[Key], Value, Key)(T* aa) pure nothrow @nogc
+{
+    return (*aa).byKeyValue();
 }
 
 Key[] keys(T : Value[Key], Value, Key)(T aa) @property

--- a/src/object.d
+++ b/src/object.d
@@ -1823,7 +1823,7 @@ V[K] dup(T : V[K], K, V)(T* aa)
     return (*aa).dup;
 }
 
-auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
+auto byKey(T : V[K], K, V)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
@@ -1831,7 +1831,7 @@ auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 
     pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
-        @property ref Key front() { return *cast(Key*)_aaRangeFrontKey(r); }
+        @property ref K front() { return *cast(K*)_aaRangeFrontKey(r); }
         void popFront() { _aaRangePopFront(r); }
         @property Result save() { return this; }
     }
@@ -1839,12 +1839,12 @@ auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byKey(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
+auto byKey(T : V[K], K, V)(T* aa) pure nothrow @nogc
 {
     return (*aa).byKey();
 }
 
-auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
+auto byValue(T : V[K], K, V)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
@@ -1852,7 +1852,7 @@ auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 
     pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
-        @property ref Value front() { return *cast(Value*)_aaRangeFrontValue(r); }
+        @property ref V front() { return *cast(V*)_aaRangeFrontValue(r); }
         void popFront() { _aaRangePopFront(r); }
         @property Result save() { return this; }
     }
@@ -1860,12 +1860,12 @@ auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
+auto byValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
 {
     return (*aa).byValue();
 }
 
-auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
+auto byKeyValue(T : V[K], K, V)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
@@ -1879,14 +1879,14 @@ auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
             {
                 // We save the pointers here so that the Pair we return
                 // won't mutate when Result.popFront is called afterwards.
-                private Key* keyp;
-                private Value* valp;
+                private K* keyp;
+                private V* valp;
 
-                @property ref inout(Key) key() inout { return *keyp; }
-                @property ref inout(Value) value() inout { return *valp; }
+                @property ref inout(K) key() inout { return *keyp; }
+                @property ref inout(V) value() inout { return *valp; }
             }
-            return Pair(cast(Key*)_aaRangeFrontKey(r),
-                        cast(Value*)_aaRangeFrontValue(r));
+            return Pair(cast(K*)_aaRangeFrontKey(r),
+                        cast(V*)_aaRangeFrontValue(r));
         }
         void popFront() { _aaRangePopFront(r); }
         @property Result save() { return this; }
@@ -1895,7 +1895,7 @@ auto byKeyValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byKeyValue(T : Value[Key], Value, Key)(T* aa) pure nothrow @nogc
+auto byKeyValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
 {
     return (*aa).byKeyValue();
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14626

Until 2.065, compiler had substituted all inout qualifiers in the Key and Value types to const, then those had passed to the template struct AssociativeArray.

https://github.com/D-Programming-Language/dmd/blob/v2.065.0/src/mtype.c#L4897

This change emulates that.

Additionally add an overload of bykeyValue function for AA pointer types.
