### PR TITLE
Fix issue 14863 - CLOCK_BOOTTIME should be optional to support <2.6.39 kernels

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2694,6 +2694,13 @@ private immutable long[__traits(allMembers, ClockType).length] _ticksPerSecond;
 // it's a normal function, we need to do some dangerous casting PLEASE take
 // care when modifying this function, and it should NOT be called except from
 // the runtime init.
+//
+// NOTE: the code below SPECIFICALLY does not assert when it cannot initialize
+// the ticks per second array. This allows cases where a clock is never used on
+// a system that doesn't support it. See bugzilla issue
+// https://issues.dlang.org/show_bug.cgi?id=14863
+// The assert will occur when someone attempts to use _ticksPerSecond for that
+// value.
 extern(C) void _d_initMonoTime()
 {
     // We need a mutable pointer to the ticksPerSecond array. Although this
@@ -2722,8 +2729,6 @@ extern(C) void _d_initMonoTime()
                 tps[i] = ticksPerSecond;
             }
         }
-        else
-            assert(0, "Failed to get the frequency of the system's monotonic clock.");
     }
     else version(OSX)
     {
@@ -2739,8 +2744,6 @@ extern(C) void _d_initMonoTime()
                 tps[i] = ticksPerSecond;
             }
         }
-        else
-            assert(0, "Failed to get the frequency of the system's monotonic clock.");
     }
     else version(Posix)
     {
@@ -2764,8 +2767,6 @@ extern(C) void _d_initMonoTime()
                     tps[i] = ts.tv_nsec >= 1000 ? 1_000_000_000L
                                                             : 1_000_000_000L / ts.tv_nsec;
                 }
-                else
-                    assert(0, "Failed to get the frequency for of the system's monotonic clock: ClockType." ~ typeStr);
             }
         }
     }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14863

I realized, MonoTime.currTime is already checking for 0 and asserting (and any use of 0 for ticksPerSecond will have a divide by zero error anyway), we should simply defer to that. I made a note in the code so people don't add the asserts back in later.

This still doesn't eliminate a segfault for anyone who actually *uses* CLOCK_BOOTTIME on an unsupported system, since assert(0) turns into halt statement, but that is really a separate issue.