### PR TITLE
Import fallocate in sys/linux/fcntl.d

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -61,6 +61,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\epoll.d \
 	$(IMPDIR)\core\sys\linux\errno.d \
 	$(IMPDIR)\core\sys\linux\execinfo.d \
+	$(IMPDIR)\core\sys\linux\fcntl.d \
 	$(IMPDIR)\core\sys\linux\link.d \
 	$(IMPDIR)\core\sys\linux\termios.d \
 	$(IMPDIR)\core\sys\linux\time.d \

--- a/src/core/sys/linux/fcntl.d
+++ b/src/core/sys/linux/fcntl.d
@@ -1,0 +1,24 @@
+module core.sys.linux.fcntl;
+
+public import core.sys.posix.fcntl;
+
+version (linux):
+extern(C):
+nothrow:
+
+// From Linux's unistd.h, stdio.h, and linux/fs.h
+enum {
+    SEEK_DATA = 3,
+    SEEK_HOLE = 4
+}
+
+// From linux/falloc.h
+enum {
+    FALLOC_FL_KEEP_SIZE = 0x01,
+    FALLOC_FL_PUNCH_HOLE = 0x02,
+    FALLOC_FL_NO_HIDE_STALE = 0x04
+}
+
+// Linux-specific fallocate
+// (http://man7.org/linux/man-pages/man2/fallocate.2.html)
+int fallocate(int fd, int mode, off_t offset, off_t len);

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -541,6 +541,9 @@ else
 int fcntl(int, int, ...);
 //int open(in char*, int, ...);
 
+// Generic Posix fallocate
+int posix_fallocate(int, off_t, off_t);
+
 //
 // Advisory Information (ADV)
 //
@@ -553,5 +556,4 @@ POSIX_FADV_DONTNEED
 POSIX_FADV_NOREUSE
 
 int posix_fadvise(int, off_t, off_t, int);
-int posix_fallocate(int, off_t, off_t);
 */

--- a/win32.mak
+++ b/win32.mak
@@ -382,6 +382,9 @@ $(IMPDIR)\core\sys\linux\errno.d : src\core\sys\linux\errno.d
 $(IMPDIR)\core\sys\linux\execinfo.d : src\core\sys\linux\execinfo.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\linux\fcntl.d : src\core\sys\linux\fcntl.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\linux\link.d : src\core\sys\linux\link.d
 	copy $** $@
 

--- a/win64.mak
+++ b/win64.mak
@@ -392,6 +392,9 @@ $(IMPDIR)\core\sys\linux\errno.d : src\core\sys\linux\errno.d
 $(IMPDIR)\core\sys\linux\execinfo.d : src\core\sys\linux\execinfo.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\linux\fcntl.d : src\core\sys\linux\fcntl.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\linux\link.d : src\core\sys\linux\link.d
 	copy $** $@
 


### PR DESCRIPTION
This adds prototypes for posix_fallocate (which was present but commented out) and the linux-specific fallocate (http://man7.org/linux/man-pages/man2/fallocate.2.html).