### PR TITLE
replace mangleC with Cprefix

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1890,36 +1890,15 @@ unittest
     static assert(!__traits(compiles, mangleFunc!(typeof(&fooCPP))("")));
 }
 
-/**
-* Mangles a C function or variable.
-*
-* Params:
-*  sym = The C symbol to mangle.
-*  dst = An optional destination buffer.
-*
-* Returns:
-*  The mangled name for a C function or variable, i.e.
-*  an underscore is prepended or not, depending on the
-*  compiler/linker tool chain
-*/
-char[] mangleC(const(char)[] sym, char[] dst = null)
-{
-    version(Win32)
-        enum string prefix = "_";
-    else version(OSX)
-        enum string prefix = "_";
-    else
-        enum string prefix = "";
-
-    auto len = sym.length + prefix.length;
-    if( dst.length < len )
-        dst.length = len;
-
-    dst[0 .. prefix.length] = prefix[];
-    dst[prefix.length .. len] = sym[];
-    return dst[0 .. len];
-}
-
+/***
+ * C name mangling is done by adding a prefix on some platforms.
+ */
+version(Win32)
+    enum string cPrefix = "_";
+else version(OSX)
+    enum string cPrefix = "_";
+else
+    enum string cPrefix = "";
 
 version(unittest)
 {

--- a/src/rt/config.d
+++ b/src/rt/config.d
@@ -36,20 +36,20 @@ module rt.config;
 // line arguments, i.e. if command line arguments are not disabled, they can override
 // options specified through the environment or embedded in the executable.
 
-import core.demangle : mangleC;
+import core.demangle : cPrefix;
 
 // put each variable in its own COMDAT by making them template instances
 template rt_envvars_enabled()
 {
-    pragma(mangle,mangleC("rt_envvars_enabled")) __gshared bool rt_envvars_enabled = false;
+    pragma(mangle, cPrefix ~ "rt_envvars_enabled") __gshared bool rt_envvars_enabled = false;
 }
 template rt_cmdline_enabled()
 {
-    pragma(mangle,mangleC("rt_cmdline_enabled")) __gshared bool rt_cmdline_enabled = true;
+    pragma(mangle, cPrefix ~ "rt_cmdline_enabled") __gshared bool rt_cmdline_enabled = true;
 }
 template rt_options()
 {
-    pragma(mangle,mangleC("rt_options")) __gshared string[] rt_options = [];
+    pragma(mangle, cPrefix ~ "rt_options") __gshared string[] rt_options = [];
 }
 
 import core.stdc.ctype : toupper;


### PR DESCRIPTION
Removes an unnecessary function and an unnecessary reference to the GC. I've never encountered a C mangling method that did more than simply add a prefix. Having an abstraction for a possibility that will never happen is useless bloat.