### PR TITLE
Issue 8973 - core.cpuid.coresPerCPU returning incorrect value. 

### DIFF
--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -735,15 +735,10 @@ void cpuidX86()
             cpuid;
             mov c, ECX;
         }
-        uint apicsize = (c>>12) & 0xF;
-        if (apicsize == 0) {
-            // use legacy method
-            if (hyperThreadingBit)  maxCores = c & 0xFF;
-            else maxCores = 1;
-        } else {
-            // maxcores = 2^ apicsize
-            maxCores = 1;
-            while (apicsize) { maxCores<<=1; --apicsize; }
+        //http://support.amd.com/TechDocs/25481.pdf pg.36
+        maxCores = 1;
+        if (hyperThreadingBit) {
+            maxCores += c & 0xFF;
         }
     }
 


### PR DESCRIPTION
maxCores for AMD is currently calculated using the theoretical maximum number of cores, not the actual enabled maximum number of cores.

This causes all bulldozer CPUs(and possibly others) to report the wrong value.

http://support.amd.com/TechDocs/25481.pdf

>The size of this field determines the maximum number of cores (MNC) that the processor could theoretically support, not the actual number of cores that are actually implemented or enabled on the processor, as indicated by CPUID Fn8000_0008_ECX[NC]. 

[issue](https://issues.dlang.org/show_bug.cgi?id=8973)