### PR TITLE
output coverage reports to $(ROOT) to avoid test interference

### DIFF
--- a/test/coverage/Makefile
+++ b/test/coverage/Makefile
@@ -12,17 +12,17 @@ all: $(NORMAL_TESTS) $(MERGE_TESTS)
 
 $(NORMAL_TESTS): $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	@rm -f src-$*.lst
-	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
-	$(QUIET)$(DIFF) src-$*.lst.exp src-$*.lst
+	@rm -f $(ROOT)/src-$*.lst
+	$(QUIET)$(ROOT)/$* $(ROOT) $(RUN_ARGS)
+	$(QUIET)$(DIFF) src-$*.lst.exp $(ROOT)/src-$*.lst
 	@touch $@
 
 $(MERGE_TESTS): $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	@rm -f src-$*.lst
-	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
-	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
-	$(QUIET)$(DIFF) src-$*.lst.exp src-$*.lst
+	@rm -f $(ROOT)/src-$*.lst
+	$(QUIET)$(ROOT)/$* $(ROOT) $(RUN_ARGS)
+	$(QUIET)$(ROOT)/$* $(ROOT) $(RUN_ARGS)
+	$(QUIET)$(DIFF) src-$*.lst.exp $(ROOT)/src-$*.lst
 	@touch $@
 
 $(ROOT)/%: $(SRC)/%.d

--- a/test/coverage/src-basic.lst.exp
+++ b/test/coverage/src-basic.lst.exp
@@ -1,5 +1,7 @@
-       |int main()
+       |import core.runtime;
+       |
+       |void main(string[] args)
        |{
-      1|    return 0;
+      1|    dmd_coverDestPath(args[1]);
        |}
 src/basic.d is 100% covered

--- a/test/coverage/src-merge.lst.exp
+++ b/test/coverage/src-merge.lst.exp
@@ -1,5 +1,8 @@
-       |int main()
+       |import core.runtime;
+       |
+       |int main(string[] args)
        |{
+      1|    dmd_coverDestPath(args[1]);
       1|    return 0;
        |}
 src/merge.d is 100% covered

--- a/test/coverage/src-merge_true.lst.exp
+++ b/test/coverage/src-merge_true.lst.exp
@@ -1,7 +1,8 @@
        |import core.runtime;
        |
-       |void main()
+       |void main(string[] args)
        |{
+      2|    dmd_coverDestPath(args[1]);
       2|    dmd_coverSetMerge(true);
        |}
 src/merge_true.d is 100% covered

--- a/test/coverage/src/basic.d
+++ b/test/coverage/src/basic.d
@@ -1,4 +1,6 @@
-int main()
+import core.runtime;
+
+void main(string[] args)
 {
-    return 0;
+    dmd_coverDestPath(args[1]);
 }

--- a/test/coverage/src/merge.d
+++ b/test/coverage/src/merge.d
@@ -1,4 +1,7 @@
-int main()
+import core.runtime;
+
+int main(string[] args)
 {
+    dmd_coverDestPath(args[1]);
     return 0;
 }

--- a/test/coverage/src/merge_true.d
+++ b/test/coverage/src/merge_true.d
@@ -1,6 +1,7 @@
 import core.runtime;
 
-void main()
+void main(string[] args)
 {
+    dmd_coverDestPath(args[1]);
     dmd_coverSetMerge(true);
 }


### PR DESCRIPTION
- release and debug tests might run in parallel