### PR TITLE
fix issue 14946 - druntime coverage tests fail intermittently

### DIFF
--- a/test/coverage/Makefile
+++ b/test/coverage/Makefile
@@ -12,17 +12,21 @@ all: $(NORMAL_TESTS) $(MERGE_TESTS)
 
 $(NORMAL_TESTS): $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	@rm -f src-$*.lst
-	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
-	$(QUIET)$(DIFF) src-$*.lst.exp src-$*.lst
+	@rm -f $(ROOT)/src-$*.lst
+	@rm -f $(ROOT)/src
+	@ln -s ../../../../src $(ROOT)/src
+	$(QUIET)cd $(ROOT) && ./$* $(RUN_ARGS)
+	$(QUIET)$(DIFF) src-$*.lst.exp $(ROOT)/src-$*.lst
 	@touch $@
 
 $(MERGE_TESTS): $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	@rm -f src-$*.lst
-	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
-	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
-	$(QUIET)$(DIFF) src-$*.lst.exp src-$*.lst
+	@rm -f $(ROOT)/src-$*.lst
+	@rm -f $(ROOT)/src
+	@ln -s ../../../../src $(ROOT)/src
+	$(QUIET)cd $(ROOT) && ./$* $(RUN_ARGS)
+	$(QUIET)cd $(ROOT) && ./$* $(RUN_ARGS)
+	$(QUIET)$(DIFF) src-$*.lst.exp $(ROOT)/src-$*.lst
 	@touch $@
 
 $(ROOT)/%: $(SRC)/%.d


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14946

The solution is very unix specific, I'm not sure what happens on windows, but it doesn't appear to run those tests.

It's also specific to the way we construct the ROOT directory, but I'm not sure of a good way to do that from ROOT itself. This at least gets the job done.

I'd much rather see a good solution to this involving direction of the runtime on where to write the coverage data.