### PR TITLE
Place SEEK_DATA, SEEK_HOLE in core.sys.linux.unistd

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -66,6 +66,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\termios.d \
 	$(IMPDIR)\core\sys\linux\time.d \
 	$(IMPDIR)\core\sys\linux\tipc.d \
+	$(IMPDIR)\core\sys\linux\unistd.d \
 	\
 	$(IMPDIR)\core\sys\linux\sys\inotify.d \
 	$(IMPDIR)\core\sys\linux\sys\mman.d \

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -222,11 +222,11 @@ else
 
 enum
 {
-    ///
+    /// Offset is relative to the beginning
     SEEK_SET,
-    ///
+    /// Offset is relative to the current position
     SEEK_CUR,
-    ///
+    /// Offset is relative to the end
     SEEK_END
 }
 

--- a/src/core/sys/linux/fcntl.d
+++ b/src/core/sys/linux/fcntl.d
@@ -6,12 +6,6 @@ version (linux):
 extern(C):
 nothrow:
 
-// From Linux's unistd.h, stdio.h, and linux/fs.h
-enum {
-    SEEK_DATA = 3,
-    SEEK_HOLE = 4
-}
-
 // From linux/falloc.h
 enum {
     FALLOC_FL_KEEP_SIZE = 0x01,

--- a/src/core/sys/linux/unistd.d
+++ b/src/core/sys/linux/unistd.d
@@ -1,0 +1,17 @@
+module core.sys.linux.unistd;
+
+public import core.sys.posix.unistd;
+
+version(linux):
+extern(C):
+nothrow:
+
+// Additional seek constants for sparse file handling
+// from Linux's unistd.h, stdio.h, and linux/fs.h
+// (see http://man7.org/linux/man-pages/man2/lseek.2.html)
+enum {
+    /// Offset is relative to the next location containing data
+    SEEK_DATA = 3,
+    /// Offset is relative to the next hole (or EOF if file is not sparse)
+    SEEK_HOLE = 4
+}

--- a/win32.mak
+++ b/win32.mak
@@ -397,6 +397,9 @@ $(IMPDIR)\core\sys\linux\time.d : src\core\sys\linux\time.d
 $(IMPDIR)\core\sys\linux\tipc.d : src\core\sys\linux\tipc.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\linux\unistd.d : src\core\sys\linux\unistd.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\linux\sys\inotify.d : src\core\sys\linux\sys\inotify.d
 	copy $** $@
 

--- a/win64.mak
+++ b/win64.mak
@@ -407,6 +407,9 @@ $(IMPDIR)\core\sys\linux\time.d : src\core\sys\linux\time.d
 $(IMPDIR)\core\sys\linux\tipc.d : src\core\sys\linux\tipc.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\linux\unistd.d : src\core\sys\linux\unistd.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\linux\sys\inotify.d : src\core\sys\linux\sys\inotify.d
 	copy $** $@
 


### PR DESCRIPTION
Pull #1344 placed them with fallocate. While the three are often used in conjunction, SEEK_DATA and SEEK_HOLE should be placed with SEEK_SET, SEEK_CUR, and SEEK_END.