### PR TITLE
fix -m32mscoff issue with errno_c.obj

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -34,8 +34,8 @@ $(mak\SRCS)
 # NOTE: a pre-compiled minit.obj has been provided in dmd for Win32 and
 #       minit.asm is not used by dmd for Linux
 
-OBJS= errno_c.obj src\rt\minit.obj
-OBJS_TO_DELETE= errno_c.obj
+OBJS= errno_c$(MODEL).obj src\rt\minit.obj
+OBJS_TO_DELETE= errno_c$(MODEL).obj
 
 ######################## Doc .html file generation ##############################
 
@@ -630,8 +630,8 @@ $(IMPDIR)\etc\linux\memoryerror.d : src\etc\linux\memoryerror.d
 
 ################### C\ASM Targets ############################
 
-errno_c.obj : src\core\stdc\errno.c
-	$(CC) -c $(CFLAGS) src\core\stdc\errno.c -oerrno_c.obj
+errno_c$(MODEL).obj : src\core\stdc\errno.c
+	$(CC) -c $(CFLAGS) src\core\stdc\errno.c -o$@
 
 src\rt\minit.obj : src\rt\minit.asm
 	$(CC) -c $(CFLAGS) src\rt\minit.asm

--- a/win64.mak
+++ b/win64.mak
@@ -43,8 +43,8 @@ $(mak\SRCS)
 # NOTE: a pre-compiled minit.obj has been provided in dmd for Win32 and
 #       minit.asm is not used by dmd for Linux
 
-OBJS= errno_c.obj
-OBJS_TO_DELETE= errno_c.obj
+OBJS= errno_c$(MODEL).obj
+OBJS_TO_DELETE= errno_c$(MODEL).obj
 
 ######################## Doc .html file generation ##############################
 
@@ -640,8 +640,8 @@ $(IMPDIR)\etc\linux\memoryerror.d : src\etc\linux\memoryerror.d
 
 ################### C\ASM Targets ############################
 
-errno_c.obj : src\core\stdc\errno.c
-	$(CC) -c $(CFLAGS) src\core\stdc\errno.c -Foerrno_c.obj
+errno_c$(MODEL).obj : src\core\stdc\errno.c
+	$(CC) -c $(CFLAGS) src\core\stdc\errno.c -Fo$@
 
 src\rt\minit.obj : src\rt\minit.asm
 	$(CC) -c $(CFLAGS) src\rt\minit.asm


### PR DESCRIPTION
- use C objs depending on MODEL so that we
  never end up with the wrong obj file in a lib