### PR TITLE
Fix building for COFF32

### DIFF
--- a/src/rt/stdio_msvc.c
+++ b/src/rt/stdio_msvc.c
@@ -36,9 +36,20 @@ int _set_output_format(int format); // VS2013-
 //extern const char* __acrt_iob_func;
 extern const char* _nullfunc = 0;
 
-#pragma comment(linker, "/alternatename:__acrt_iob_func=_nullfunc")
-#pragma comment(linker, "/alternatename:__iob_func=_nullfunc")
-#pragma comment(linker, "/alternatename:_set_output_format=_nullfunc")
+#if defined _M_IX86
+    #define C_PREFIX "_"
+#elif defined _M_X64 || defined _M_ARM || defined _M_ARM64
+    #define C_PREFIX ""
+#else
+    #error Unsupported architecture
+#endif
+
+#define DECLARE_ALTERNATE_NAME(name, alternate_name)  \
+    __pragma(comment(linker, "/alternatename:" C_PREFIX #name "=" C_PREFIX #alternate_name))
+
+DECLARE_ALTERNATE_NAME ("__acrt_iob_func", "_nullfunc");
+DECLARE_ALTERNATE_NAME ("__iob_func", "_nullfunc");
+DECLARE_ALTERNATE_NAME ("_set_output_format", "_nullfunc");
 
 void init_msvc()
 {
@@ -65,25 +76,25 @@ void init_msvc()
 // VS2015+ provides C99-conformant (v)snprintf functions, so weakly
 // link to legacy _(v)snprintf (not C99-conformant!) for VS2013- only
 
-#pragma comment(linker, "/alternatename:snprintf=_snprintf")
-#pragma comment(linker, "/alternatename:vsnprintf=_vsnprintf")
+DECLARE_ALTERNATE_NAME ("snprintf", "_snprintf");
+DECLARE_ALTERNATE_NAME ("vsnprintf", "_vsnprintf");
 
 // VS2013- implements these functions as macros, VS2015+ provides symbols
 
-#pragma comment(linker, "/alternatename:_fputc_nolock=_msvc_fputc_nolock")
-#pragma comment(linker, "/alternatename:_fgetc_nolock=_msvc_fgetc_nolock")
-#pragma comment(linker, "/alternatename:rewind=_msvc_rewind")
-#pragma comment(linker, "/alternatename:clearerr=_msvc_clearerr")
-#pragma comment(linker, "/alternatename:feof=_msvc_feof")
-#pragma comment(linker, "/alternatename:ferror=_msvc_ferror")
-#pragma comment(linker, "/alternatename:fileno=_msvc_fileno")
+DECLARE_ALTERNATE_NAME ("_fputc_nolock", "_msvc_fputc_nolock");
+DECLARE_ALTERNATE_NAME ("_fgetc_nolock", "_msvc_fgetc_nolock");
+DECLARE_ALTERNATE_NAME ("rewind", "_msvc_rewind");
+DECLARE_ALTERNATE_NAME ("clearerr", "_msvc_clearerr");
+DECLARE_ALTERNATE_NAME ("feof", "_msvc_feof");
+DECLARE_ALTERNATE_NAME ("ferror", "_msvc_ferror");
+DECLARE_ALTERNATE_NAME ("fileno", "_msvc_fileno");
 
 // VS2013- helper functions
 int _filbuf(FILE* fp);
 int _flsbuf(int c, FILE* fp);
 
-#pragma comment(linker, "/alternatename:_filbuf=_nullfunc")
-#pragma comment(linker, "/alternatename:_flsbuf=_nullfunc")
+DECLARE_ALTERNATE_NAME ("_filbuf", "_nullfunc");
+DECLARE_ALTERNATE_NAME ("_flsbuf", "_nullfunc");
 
 int _msvc_fputc_nolock(int c, FILE* fp)
 {


### PR DESCRIPTION
Alternate symbol name declarations need prefix "_" for Win32 builds.