### PR TITLE
Fix Issue 14785 - Some corner cases are not handled properly by core.checkedint.

### DIFF
--- a/src/core/checkedint.d
+++ b/src/core/checkedint.d
@@ -218,8 +218,7 @@ long subs(long x, long y, ref bool overflow)
 {
     long r = cast(ulong)x - cast(ulong)y;
     if (x <  0 && y >= 0 && r >= 0 ||
-        x >= 0 && y <  0 && r <  0 ||
-        y == long.min)
+        x >= 0 && y <  0 && (r <  0 || y == long.min))
         overflow = true;
     return r;
 }
@@ -232,6 +231,8 @@ unittest
     assert(subs(1L, -long.max + 1, overflow) == long.max);
     assert(!overflow);
     assert(subs(long.min + 1, 1, overflow) == long.min);
+    assert(!overflow);
+    assert(subs(-1L, long.min, overflow) == long.max);
     assert(!overflow);
     assert(subs(long.max, -1, overflow) == long.min);
     assert(overflow);
@@ -415,7 +416,8 @@ pragma(inline, true)
 long muls(long x, long y, ref bool overflow)
 {
     long r = cast(ulong)x * cast(ulong)y;
-    if (x && (r / x) != y)
+    enum not0or1 = ~1L;
+    if((x & not0or1) && ((r == y)? r : (r / x) != y))
         overflow = true;
     return r;
 }
@@ -432,6 +434,9 @@ unittest
     assert(muls(long.min, 1L, overflow) == long.min);
     assert(!overflow);
     assert(muls(long.max, 2L, overflow) == (long.max * 2));
+    assert(overflow);
+    overflow = false;
+    assert(muls(-1L, long.min, overflow) == long.min);
     assert(overflow);
     overflow = false;
     assert(muls(long.min, -1L, overflow) == long.min);


### PR DESCRIPTION
This pull request fixes druntime [Issue #14785](https://issues.dlang.org/show_bug.cgi?id=14785).

```D
/** Test cases that fail without this PR **/

import core.checkedint;
void main(string[] args)
{
    bool overflow = false;
    assert(subs(-1L, long.min, overflow) == long.max);
    assert(!overflow); // Assertion failure

    overflow = false;
    assert(muls(-1L, long.min, overflow) == long.min); // Floating Point Exception!
    assert(overflow);
}
```