### PR TITLE
mak/SRCS: Add all modules with struct definitions

### DIFF
--- a/mak/SRCS
+++ b/mak/SRCS
@@ -25,6 +25,8 @@ SRCS=\
 	src\core\stdc\ctype.d \
 	src\core\stdc\errno.d \
 	src\core\stdc\fenv.d \
+	src\core\stdc\inttypes.d \
+	src\core\stdc\locale.d \
 	src\core\stdc\math.d \
 	src\core\stdc\signal.d \
 	src\core\stdc\stdarg.d \
@@ -44,28 +46,73 @@ SRCS=\
 	src\core\sync\rwmutex.d \
 	src\core\sync\semaphore.d \
 	\
+	src\core\sys\freebsd\dlfcn.d \
 	src\core\sys\freebsd\execinfo.d \
+	src\core\sys\freebsd\sys\elf32.d \
+	src\core\sys\freebsd\sys\elf64.d \
+	src\core\sys\freebsd\sys\elf_common.d \
 	src\core\sys\freebsd\sys\event.d \
+	src\core\sys\freebsd\sys\link_elf.d \
 	\
+	src\core\sys\linux\dlfcn.d \
+	src\core\sys\linux\elf.d \
+	src\core\sys\linux\epoll.d \
+	src\core\sys\linux\link.d \
 	src\core\sys\linux\stdio.d \
+	src\core\sys\linux\sys\inotify.d \
+	src\core\sys\linux\sys\signalfd.d \
+	src\core\sys\linux\sys\sysinfo.d \
 	src\core\sys\linux\tipc.d \
 	\
-	src\core\sys\posix\signal.d \
+	src\core\sys\osx\mach\loader.d \
+	src\core\sys\osx\mach\semaphore.d \
+	src\core\sys\osx\mach\thread_act.d \
+	src\core\sys\osx\sys\event.d \
+	\
+	src\core\sys\posix\arpa\inet.d \
 	src\core\sys\posix\dirent.d \
+	src\core\sys\posix\dlfcn.d \
+	src\core\sys\posix\fcntl.d \
+	src\core\sys\posix\grp.d \
+	src\core\sys\posix\netdb.d \
+	src\core\sys\posix\netinet\in_.d \
+	src\core\sys\posix\net\if_.d \
+	src\core\sys\posix\poll.d \
+	src\core\sys\posix\pthread.d \
+	src\core\sys\posix\pwd.d \
+	src\core\sys\posix\sched.d \
+	src\core\sys\posix\semaphore.d \
+	src\core\sys\posix\setjmp.d \
+	src\core\sys\posix\signal.d \
+	src\core\sys\posix\sys\ioctl.d \
+	src\core\sys\posix\sys\ipc.d \
+	src\core\sys\posix\sys\mman.d \
+	src\core\sys\posix\sys\msg.d \
 	src\core\sys\posix\sys\resource.d \
 	src\core\sys\posix\sys\select.d \
+	src\core\sys\posix\sys\shm.d \
 	src\core\sys\posix\sys\socket.d \
 	src\core\sys\posix\sys\stat.d \
-	src\core\sys\posix\sys\wait.d \
-	src\core\sys\posix\netdb.d \
-	src\core\sys\posix\sys\ioctl.d \
+	src\core\sys\posix\sys\statvfs.d \
+	src\core\sys\posix\sys\time.d \
+	src\core\sys\posix\sys\types.d \
+	src\core\sys\posix\sys\uio.d \
+	src\core\sys\posix\sys\un.d \
 	src\core\sys\posix\sys\utsname.d \
-	src\core\sys\posix\netinet\in_.d \
-	src\core\sys\posix\arpa\inet.d \
+	src\core\sys\posix\sys\wait.d \
+	src\core\sys\posix\termios.d \
+	src\core\sys\posix\time.d \
+	src\core\sys\posix\ucontext.d \
+	src\core\sys\posix\utime.d \
 	\
+	src\core\sys\solaris\dlfcn.d \
+	src\core\sys\solaris\libelf.d \
+	src\core\sys\solaris\link.d \
+	src\core\sys\solaris\sys\elf.d \
+	src\core\sys\solaris\sys\link.d \
 	src\core\sys\solaris\sys\priocntl.d \
-	src\core\sys\solaris\sys\types.d \
 	src\core\sys\solaris\sys\procset.d \
+	src\core\sys\solaris\sys\types.d \
 	\
 	src\core\sys\windows\com.d \
 	src\core\sys\windows\dbghelp.d \

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -23,7 +23,7 @@ public enum    MSG_COPY = 4 << 12; // octal!40000
 
 struct msgbuf {
     c_long mtype;
-    char mtext[1];
+    char[1] mtext;
 };
 
 struct msginfo {


### PR DESCRIPTION
Fixes linker errors when trying to define an array of structs.

Works around [issue 14992](https://issues.dlang.org/show_bug.cgi?id=14992) to fix [issue 14918](https://issues.dlang.org/show_bug.cgi?id=14918). Basically this just adds all modules which define structs to fix this class of errors throughout Druntime, but obviously a compiler fix would be better. Might be worth waiting to see if this can be fixed in the compiler.