### PR TITLE
Mark functions in core.stdc.math as Pure

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -18,6 +18,7 @@ private import core.stdc.config;
 extern (C):
 @trusted: // All functions here operate on floating point and integer values only.
 nothrow:
+pure:
 @nogc:
 
 ///


### PR DESCRIPTION
As far as I know, all of the functions in `core.stdc.math` are all weekly pure, so it is safe to mark them as so. After this is pulled, many of the functions in `std.math` can be marked as pure, which would fix [issue 11320](https://issues.dlang.org/show_bug.cgi?id=11320).