### PR TITLE
Accept identifiers instead of strings in `DECLARE_ALTERNATE_NAME` macro.

### DIFF
--- a/src/rt/stdio_msvc.c
+++ b/src/rt/stdio_msvc.c
@@ -47,9 +47,9 @@ extern const char* _nullfunc = 0;
 #define DECLARE_ALTERNATE_NAME(name, alternate_name)  \
     __pragma(comment(linker, "/alternatename:" C_PREFIX #name "=" C_PREFIX #alternate_name))
 
-DECLARE_ALTERNATE_NAME ("__acrt_iob_func", "_nullfunc");
-DECLARE_ALTERNATE_NAME ("__iob_func", "_nullfunc");
-DECLARE_ALTERNATE_NAME ("_set_output_format", "_nullfunc");
+DECLARE_ALTERNATE_NAME (__acrt_iob_func, _nullfunc);
+DECLARE_ALTERNATE_NAME (__iob_func, _nullfunc);
+DECLARE_ALTERNATE_NAME (_set_output_format, _nullfunc);
 
 void init_msvc()
 {
@@ -76,25 +76,25 @@ void init_msvc()
 // VS2015+ provides C99-conformant (v)snprintf functions, so weakly
 // link to legacy _(v)snprintf (not C99-conformant!) for VS2013- only
 
-DECLARE_ALTERNATE_NAME ("snprintf", "_snprintf");
-DECLARE_ALTERNATE_NAME ("vsnprintf", "_vsnprintf");
+DECLARE_ALTERNATE_NAME (snprintf, _snprintf);
+DECLARE_ALTERNATE_NAME (vsnprintf, _vsnprintf);
 
 // VS2013- implements these functions as macros, VS2015+ provides symbols
 
-DECLARE_ALTERNATE_NAME ("_fputc_nolock", "_msvc_fputc_nolock");
-DECLARE_ALTERNATE_NAME ("_fgetc_nolock", "_msvc_fgetc_nolock");
-DECLARE_ALTERNATE_NAME ("rewind", "_msvc_rewind");
-DECLARE_ALTERNATE_NAME ("clearerr", "_msvc_clearerr");
-DECLARE_ALTERNATE_NAME ("feof", "_msvc_feof");
-DECLARE_ALTERNATE_NAME ("ferror", "_msvc_ferror");
-DECLARE_ALTERNATE_NAME ("fileno", "_msvc_fileno");
+DECLARE_ALTERNATE_NAME (_fputc_nolock, _msvc_fputc_nolock);
+DECLARE_ALTERNATE_NAME (_fgetc_nolock, _msvc_fgetc_nolock);
+DECLARE_ALTERNATE_NAME (rewind, _msvc_rewind);
+DECLARE_ALTERNATE_NAME (clearerr, _msvc_clearerr);
+DECLARE_ALTERNATE_NAME (feof, _msvc_feof);
+DECLARE_ALTERNATE_NAME (ferror, _msvc_ferror);
+DECLARE_ALTERNATE_NAME (fileno, _msvc_fileno);
 
 // VS2013- helper functions
 int _filbuf(FILE* fp);
 int _flsbuf(int c, FILE* fp);
 
-DECLARE_ALTERNATE_NAME ("_filbuf", "_nullfunc");
-DECLARE_ALTERNATE_NAME ("_flsbuf", "_nullfunc");
+DECLARE_ALTERNATE_NAME (_filbuf, _nullfunc);
+DECLARE_ALTERNATE_NAME (_flsbuf, _nullfunc);
 
 int _msvc_fputc_nolock(int c, FILE* fp)
 {


### PR DESCRIPTION
Stringizing operator ('#') adds extra quotes when used with string macro argument.

Causing commit: de0e1e10b4d88cc8e1657f326150f7565f4a9ef3, pull #1363.