### PR TITLE
Properly free module info when using linker-generated section brackets

### DIFF
--- a/src/core/sys/bionic/fcntl.d
+++ b/src/core/sys/bionic/fcntl.d
@@ -1,0 +1,5 @@
+module core.sys.bionic.fcntl;
+
+version(CRuntime_Bionic) extern(C) nothrow @nogc:
+
+enum LOCK_EX = 2;

--- a/src/core/sys/bionic/unistd.d
+++ b/src/core/sys/bionic/unistd.d
@@ -1,0 +1,5 @@
+module core.sys.bionic.unistd;
+
+version(CRuntime_Bionic) extern(C) nothrow @nogc:
+
+int flock(int, int) @trusted;

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -499,8 +499,6 @@ else version( CRuntime_Bionic )
     enum F_WRLCK        = 1;
     enum F_UNLCK        = 2;
 
-    enum LOCK_EX        = 2;
-
     version (X86)
     {
         enum O_CREAT        = 0x40;     // octal     0100

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -1263,7 +1263,6 @@ else version( FreeBSD )
 else version( CRuntime_Bionic )
 {
     int        fchdir(int) @trusted;
-    int        flock(int, int) @trusted;
     pid_t      getpgid(pid_t) @trusted;
     int        lchown(in char*, uid_t, gid_t);
     int        nice(int) @trusted;

--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -399,7 +399,11 @@ version (Windows) HANDLE handle(int fd)
 void lockFile(int fd)
 {
     version (CRuntime_Bionic)
-        core.sys.posix.unistd.flock(fd, LOCK_EX); // exclusive lock
+    {
+        import core.sys.bionic.fcntl : LOCK_EX;
+        import core.sys.bionic.unistd : flock;
+        flock(fd, LOCK_EX); // exclusive lock
+    }
     else version (Posix)
         lockf(fd, F_LOCK, 0); // exclusive lock
     else version (Windows)

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -74,7 +74,6 @@ void initSections()
 
 void finiSections()
 {
-    .free(cast(void*)_sections.modules.ptr);
     pthread_key_delete(_tlsKey);
 }
 

--- a/src/rt/sections_solaris.d
+++ b/src/rt/sections_solaris.d
@@ -69,7 +69,6 @@ void initSections()
 
 void finiSections()
 {
-    .free(cast(void*)_sections.modules.ptr);
 }
 
 void[] initTLSRanges()


### PR DESCRIPTION
The recently-merged support for linker-generated section brackets (#1379) causes a segfault on Android, when `rt_term` tries to free module info that is no longer malloced.  I'm guessing it broke for Solaris too, though I haven't tested it.  This PR seems to fix it- all druntime and phobos tests on Android/x86 and linux/x86 pass locally- let me know if any further tweaks are necessary.