### PR TITLE
Bug 15073: statically-initialize SIGRTMIN/MAX

### DIFF
--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -108,10 +108,24 @@ union sigval
 version( Solaris )
 {
     import core.sys.posix.unistd;
-    private int _sigrtmin() { return cast(int) sysconf(_SC_SIGRT_MIN); }
-    private int _sigrtmax() { return cast(int) sysconf(_SC_SIGRT_MAX); }
+
+    @property int SIGRTMIN() nothrow @nogc {
+        static int sig = -1;
+        if (sig == -1) {
+            sig = cast(int)sysconf(_SC_SIGRT_MIN);
+        }
+        return sig;
+    }
+
+    @property int SIGRTMAX() nothrow @nogc {
+        static int sig = -1;
+        if (sig == -1) {
+            sig = cast(int)sysconf(_SC_SIGRT_MAX);
+        }
+        return sig;
+    }
 }
-else version( Posix )
+else version( linux )
 {
     private extern (C) nothrow @nogc
     {
@@ -119,25 +133,23 @@ else version( Posix )
         int __libc_current_sigrtmax();
     }
 
-    alias __libc_current_sigrtmin _sigrtmin;
-    alias __libc_current_sigrtmax _sigrtmax;
-}
-
-@property int SIGRTMIN() {
-    static int sig = -1;
-    if (sig == -1) {
-        sig = _sigrtmin();
+    @property int SIGRTMIN() nothrow @nogc {
+        static int sig = -1;
+        if (sig == -1) {
+            sig = __libc_current_sigrtmin();
+        }
+        return sig;
     }
-    return sig;
-}
 
-@property int SIGRTMAX() {
-    static int sig = -1;
-    if (sig == -1) {
-        sig = _sigrtmax();
+    @property int SIGRTMAX() nothrow @nogc {
+        static int sig = -1;
+        if (sig == -1) {
+            sig = __libc_current_sigrtmax();
+        }
+        return sig;
     }
-    return sig;
 }
+// Note: it appears that FreeBSD/OSX do not support realtime signals
 
 version( linux )
 {

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -110,7 +110,7 @@ version( Solaris )
     import core.sys.posix.unistd;
 
     @property int SIGRTMIN() nothrow @nogc {
-        static int sig = -1;
+        __gshared static int sig = -1;
         if (sig == -1) {
             sig = cast(int)sysconf(_SC_SIGRT_MIN);
         }
@@ -118,7 +118,7 @@ version( Solaris )
     }
 
     @property int SIGRTMAX() nothrow @nogc {
-        static int sig = -1;
+        __gshared static int sig = -1;
         if (sig == -1) {
             sig = cast(int)sysconf(_SC_SIGRT_MAX);
         }
@@ -134,7 +134,7 @@ else version( linux )
     }
 
     @property int SIGRTMIN() nothrow @nogc {
-        static int sig = -1;
+        __gshared static int sig = -1;
         if (sig == -1) {
             sig = __libc_current_sigrtmin();
         }
@@ -142,7 +142,7 @@ else version( linux )
     }
 
     @property int SIGRTMAX() nothrow @nogc {
-        static int sig = -1;
+        __gshared static int sig = -1;
         if (sig == -1) {
             sig = __libc_current_sigrtmax();
         }

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -149,7 +149,12 @@ else version( linux )
         return sig;
     }
 }
-// Note: it appears that FreeBSD/OSX do not support realtime signals
+else version (FreeBSD) {
+    // https://github.com/freebsd/freebsd/blob/e79c62ff68fc74d88cb6f479859f6fae9baa5101/sys/sys/signal.h#L117
+    enum SIGRTMIN = 65;
+    enum SIGRTMAX = 126;
+}
+// Note: it appears that FreeBSD (prior to 7) and OSX do not support realtime signals
 
 version( linux )
 {

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -110,9 +110,6 @@ version( Solaris )
     import core.sys.posix.unistd;
     private int _sigrtmin() { return cast(int) sysconf(_SC_SIGRT_MIN); }
     private int _sigrtmax() { return cast(int) sysconf(_SC_SIGRT_MAX); }
-
-    alias _sigrtmin SIGRTMIN;
-    alias _sigrtmax SIGRTMAX;
 }
 else version( Posix )
 {
@@ -122,8 +119,24 @@ else version( Posix )
         int __libc_current_sigrtmax();
     }
 
-    alias __libc_current_sigrtmin SIGRTMIN;
-    alias __libc_current_sigrtmax SIGRTMAX;
+    alias __libc_current_sigrtmin _sigrtmin;
+    alias __libc_current_sigrtmax _sigrtmax;
+}
+
+@property int SIGRTMIN() {
+    static int sig = -1;
+    if (sig == -1) {
+        sig = _sigrtmin();
+    }
+    return sig;
+}
+
+@property int SIGRTMAX() {
+    static int sig = -1;
+    if (sig == -1) {
+        sig = _sigrtmax();
+    }
+    return sig;
 }
 
 version( linux )


### PR DESCRIPTION
They were aliases to private functions, which meant they never worked. This fixes https://issues.dlang.org/show_bug.cgi?id=15073