### PR TITLE
Fix tests for druntime so debug and release tests do not conflict if run in parallel

### DIFF
--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -27,9 +27,9 @@ $(ROOT)/unittest_assert.done: $(ROOT)/unittest_assert
 
 $(ROOT)/line_trace.done: $(ROOT)/line_trace
 	@echo Testing line_trace
-	@rm -f line_trace.output
-	$(QUIET)./$(ROOT)/line_trace $(RUN_ARGS) >line_trace.output
-	$(QUIET)$(SED) "s/\[0x[0-9a-f]*\]/\[ADDR\]/g" line_trace.output | $(DIFF) line_trace.exp -
+	@rm -f $(ROOT)/line_trace.output
+	$(QUIET)./$(ROOT)/line_trace $(RUN_ARGS) > $(ROOT)/line_trace.output
+	$(QUIET)$(SED) "s/\[0x[0-9a-f]*\]/\[ADDR\]/g" $(ROOT)/line_trace.output | $(DIFF) line_trace.exp -
 	@touch $@
 
 $(ROOT)/unittest_assert: DFLAGS+=-unittest

--- a/test/profile/Makefile
+++ b/test/profile/Makefile
@@ -1,27 +1,12 @@
-# set from top makefile
-OS:=
-MODEL:=
-DMD:=
-DRUNTIME:=
-DRUNTIMESO:=
-QUIET:=
-LINKDL:=
+include ../common.mak
 
-SRC:=src
-ROOT:=./obj/$(OS)/$(MODEL)/$(BUILD)
-TESTS:=$(addprefix $(ROOT)/,$(addsuffix .done,profile profilegc both))
+TESTS:=profile profilegc both
 
 DIFF:=diff
 GREP:=grep
 
-ifneq (default,$(MODEL))
-	MODEL_FLAG:=-m$(MODEL)
-endif
-CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -L$(DRUNTIME) -defaultlib= -debuglib=
-
 .PHONY: all clean
-all: $(TESTS)
+all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
 $(ROOT)/profile.done: DFLAGS+=-profile
 $(ROOT)/profile.done: $(ROOT)/%.done: $(ROOT)/%
@@ -56,4 +41,4 @@ $(ROOT)/%: $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$(ROOT)/$* $<
 
 clean:
-	rm -rf obj *.log *.def
+	rm -rf $(ROOT) *.log *.def

--- a/test/profile/Makefile
+++ b/test/profile/Makefile
@@ -8,7 +8,7 @@ QUIET:=
 LINKDL:=
 
 SRC:=src
-ROOT:=./obj/$(OS)/$(MODEL)
+ROOT:=./obj/$(OS)/$(MODEL)/$(BUILD)
 TESTS:=$(addprefix $(ROOT)/,$(addsuffix .done,profile profilegc both))
 
 DIFF:=diff

--- a/test/profile/Makefile
+++ b/test/profile/Makefile
@@ -31,7 +31,7 @@ $(ROOT)/both.done: $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	@rm -f $(ROOT)/both.log $(ROOT)/both.def $(ROOT)/bothgc.log
 	$(QUIET)$(ROOT)/$* $(ROOT)/both.log $(ROOT)/both.def $(ROOT)/bothgc.log
-	$(QUIET)$(GREP) -q '1 .*_Dmain' $(ROOT)/mytrace.log
+	$(QUIET)$(GREP) -q '1 .*_Dmain' $(ROOT)/both.log
 	$(QUIET)$(GREP) -q '1000 .*both.Num\* both.foo(uint)' $(ROOT)/both.log
 	$(QUIET)$(DIFF) both.def.exp $(ROOT)/both.def
 	$(QUIET)$(DIFF) bothgc.log.exp $(ROOT)/bothgc.log


### PR DESCRIPTION
See for instance, this test: https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=1739475&isPull=true

Output:
```
make[2]: Leaving directory `/home/braddr/sandbox/at-client/pull-1739475-Linux_32_64/druntime/test/exceptions'
make[2]: Entering directory `/home/braddr/sandbox/at-client/pull-1739475-Linux_32_64/druntime/test/profile'
Testing basic
Testing merge
Testing merge_true
make[2]: Leaving directory `/home/braddr/sandbox/at-client/pull-1739475-Linux_32_64/druntime/test/coverage'
make[2]: Entering directory `/home/braddr/sandbox/at-client/pull-1739475-Linux_32_64/druntime/test/profile'
Testing profile
make[2]: execvp: ./obj/linux/64/profile: Permission denied
make[2]: *** [obj/linux/64/profile.done] Error 127
make[2]: Leaving directory `/home/braddr/sandbox/at-client/pull-1739475-Linux_32_64/druntime/test/profile'
make[1]: *** [test/profile/.run] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: Entering directory `/home/braddr/sandbox/at-client/pull-1739475-Linux_32_64/druntime/test/shared'
Testing profile
Testing profilegc
```
The repeated lines are the two threads both testing the profile directory at once. The profile Makefile did not take into account the BUILD variable when constructing its output directory.