### PR TITLE
Remove tests from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ trace.log
 Makefile
 /errno_c.obj
 make
-test/*

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,4 @@
+**/generated/
+**/obj/
+**/*.log
+**/*.output


### PR DESCRIPTION
For a reason, the content of the test folder is in the gitignore preventing people from adding or fixing tests.