### PR TITLE
Use new version identifier SystemZ instead of S390X.

### DIFF
--- a/benchmark/gcbench/vdparser.extra/vdc/versions.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/versions.d
@@ -80,7 +80,7 @@ static @property int[string] sPredefinedVersions()
             "SPARC_HardFloat" : -1,
             "SPARC64" : -1,
             "S390" : -1,
-            "S390X" : -1,
+            "SystemZ" : -1,
             "HPPA" : -1,
             "HPPA64" : -1,
             "SH" : -1,

--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -80,7 +80,7 @@ else version (S390)
     }
 }
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/s390/bits/mman.h
-else version (S390X)
+else version (SystemZ)
 {
     static if (__USE_MISC) enum
     {

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -223,7 +223,7 @@ version( CRuntime_Glibc )
         private enum DEFAULTS = true;
     else version (S390)
         private enum DEFAULTS = true;
-    else version (S390X)
+    else version (SystemZ)
         private enum DEFAULTS = true;
     else version (IA64)
         private enum DEFAULTS = true;

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -462,7 +462,7 @@ version (CRuntime_Glibc)
         enum __SIZEOF_PTHREAD_BARRIER_T = 20;
         enum __SIZEOF_PTHREAD_BARRIERATTR_T = 4;
     }
-    else version (S390X)
+    else version (SystemZ)
     {
         enum __SIZEOF_PTHREAD_ATTR_T = 56;
         enum __SIZEOF_PTHREAD_MUTEX_T = 40;


### PR DESCRIPTION
The 64-bit architecture is called System z since 2000.