### PR TITLE
Allow functions that override _d_throwc to call original implementation

### DIFF
--- a/src/rt/deh_win32.d
+++ b/src/rt/deh_win32.d
@@ -614,7 +614,7 @@ private void throwImpl(Object h)
                    1, cast(void *)&h);
 }
 
-extern(C) void _d_throwc(Object h)
+extern(C) void onThrow(Object h)
 {
     // set up a stack frame for trace unwinding
     version (AsmX86)
@@ -637,6 +637,11 @@ extern(C) void _d_throwc(Object h)
     {
         throwImpl(h);
     }
+}
+
+extern(C) void _d_throwc(Object h)
+{
+    return onThrow(h);
 }
 
 /***********************************

--- a/src/rt/deh_win64_posix.d
+++ b/src/rt/deh_win64_posix.d
@@ -196,12 +196,11 @@ size_t __eh_find_caller(size_t regbp, size_t *pretaddr)
     return bp;
 }
 
-
 /***********************************
- * Throw a D object.
+ * Throw a D object, actual implementation
  */
 
-extern (C) void _d_throwc(Object h)
+extern (C) void onThrow(Object h)
 {
     size_t regebp;
 
@@ -476,3 +475,12 @@ extern (C) void _d_throwc(Object h)
     terminate();
 }
 
+
+/***********************************
+ * Throw a D object
+ */
+
+extern (C) void _d_throwc(Object h)
+{
+    return onThrow(h);
+}


### PR DESCRIPTION
Implements what I suggested here: http://forum.dlang.org/thread/uwfacejyzpyjwrzvlspg@forum.dlang.org

Allows users to override `_d_throwc` but still let's them call the original implementation (`onThrow`) in this case. 

I chose `onThrow` because it follows the pattern used for [`_d_assert`](https://github.com/D-Programming-Language/druntime/blob/bce3f9b39396cbdd34569b0ef9e5e0d1f4111041/src/core/exception.d#L605) which calls `OnAssertError` 