### PR TITLE
rename TypeInfo's init method to initializer

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -4,9 +4,32 @@ $(COMMENT Pending changelog for 2.069.2.
 )
 
 $(BUGSTITLE Library Changes,
+
+$(LI $(RELATIVE_LINK2 TypeInfo.initializer, `TypeInfo.init` has been renamed to
+    `TypeInfo.initializer`.))
+)
+
 )
 
 $(BUGSTITLE Library Changes,
+
+$(LI $(LNAME2 TypeInfo.initializer, `TypeInfo.init` has been renamed to
+    `TypeInfo.initializer`.)
+
+    $(P The method `TypeInfo.init` has been renamed to
+        $(A ../phobos-prerelease/object.html#.TypeInfo.initializer,
+        `TypeInfo.initializer`).
+        This is necessary because the method clashes with the
+        $(A ../property.html#init, type property of the same name).
+    )
+    $(P An alias with the old name has been added, and it's supposed to stay
+        around through version 2.071.0. It's scheduled to be deprecated with the
+        2.072.0 release, and is going to be `@disable`d with the 2.073.0
+        release. Finally, the special casing is going to be removed with the
+        2.074.0 release, so that the type property `init` takes over.
+    )
+)
+
 )
 
 Macros:

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -86,7 +86,7 @@ private struct Demangle
         //throw new ParseException( msg );
         debug(info) printf( "error: %.*s\n", cast(int) msg.length, msg.ptr );
         throw __ctfe ? new ParseException(msg)
-                     : cast(ParseException) cast(void*) typeid(ParseException).init;
+                     : cast(ParseException) cast(void*) typeid(ParseException).initializer;
 
     }
 
@@ -95,7 +95,7 @@ private struct Demangle
     {
         //throw new OverflowException( msg );
         debug(info) printf( "overflow: %.*s\n", cast(int) msg.length, msg.ptr );
-        throw cast(OverflowException) cast(void*) typeid(OverflowException).init;
+        throw cast(OverflowException) cast(void*) typeid(OverflowException).initializer;
     }
 
 

--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -672,7 +672,7 @@ private T staticError(T, Args...)(auto ref Args args)
         static assert(__traits(classInstanceSize, T) <= _store.length,
                       T.stringof ~ " is too large for staticError()");
 
-        _store[0 .. __traits(classInstanceSize, T)] = typeid(T).init[];
+        _store[0 .. __traits(classInstanceSize, T)] = typeid(T).initializer[];
         return cast(T) _store.ptr;
     }
     auto res = (cast(T function() @trusted pure nothrow @nogc) &get)();

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -145,7 +145,7 @@ class Mutex :
             int rc = pthread_mutex_lock( &m_hndl );
             if( rc )
             {
-                SyncError syncErr = cast(SyncError) cast(void*) typeid(SyncError).init;
+                SyncError syncErr = cast(SyncError) cast(void*) typeid(SyncError).initializer;
                 syncErr.msg = "Unable to lock mutex.";
                 throw syncErr;
             }
@@ -176,7 +176,7 @@ class Mutex :
             int rc = pthread_mutex_unlock( &m_hndl );
             if( rc )
             {
-                SyncError syncErr = cast(SyncError) cast(void*) typeid(SyncError).init;
+                SyncError syncErr = cast(SyncError) cast(void*) typeid(SyncError).initializer;
                 syncErr.msg = "Unable to unlock mutex.";
                 throw syncErr;
             }

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1605,7 +1605,7 @@ private:
     {
         foreach (ref lock; _locks)
         {
-            lock[] = typeid(Mutex).init[];
+            lock[] = typeid(Mutex).initializer[];
             (cast(Mutex)lock.ptr).__ctor();
         }
     }

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -291,7 +291,7 @@ struct GC
     {
         config.initialize();
 
-        mutexStorage[] = typeid(GCMutex).init[];
+        mutexStorage[] = typeid(GCMutex).initializer[];
         gcLock = cast(GCMutex) mutexStorage.ptr;
         gcLock.__ctor();
         gcx = cast(Gcx*)cstdlib.calloc(1, Gcx.sizeof);

--- a/src/object.d
+++ b/src/object.d
@@ -287,7 +287,14 @@ class TypeInfo
 
     /// Return default initializer.  If the type should be initialized to all zeros,
     /// an array with a null ptr and a length equal to the type size will be returned.
-    abstract const(void)[] init() nothrow pure const @safe @nogc;
+    abstract const(void)[] initializer() nothrow pure const @safe @nogc;
+
+    /// $(RED Scheduled for deprecation.) Please use `initializer` instead.
+    alias init = initializer; // added in 2.070, to stay in 2.071
+    version(none) deprecated alias init = initializer; // planned for 2.072
+    version(none) @disable static const(void)[] init(); // planned for 2.073
+    /* Planned for 2.074: Remove init, making way for the init type property,
+    fixing issue 12233. */
 
     /// Get flags for type: 1 means GC should scan for pointers,
     /// 2 means arg of this type is passed in XMM register
@@ -339,7 +346,11 @@ class TypeInfo_Typedef : TypeInfo
 
     override @property inout(TypeInfo) next() nothrow pure inout { return base.next; }
     override @property uint flags() nothrow pure const { return base.flags; }
-    override const(void)[] init() const { return m_init.length ? m_init : base.init(); }
+
+    override const(void)[] initializer() const
+    {
+        return m_init.length ? m_init : base.initializer();
+    }
 
     override @property size_t talign() nothrow pure const { return base.talign; }
 
@@ -398,7 +409,7 @@ class TypeInfo_Pointer : TypeInfo
         return (void*).sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. (void*).sizeof];
     }
@@ -472,7 +483,7 @@ class TypeInfo_Array : TypeInfo
         return (void[]).sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. (void[]).sizeof];
     }
@@ -588,7 +599,11 @@ class TypeInfo_StaticArray : TypeInfo
             GC.free(pbuffer);
     }
 
-    override const(void)[] init() nothrow pure const { return value.init(); }
+    override const(void)[] initializer() nothrow pure const
+    {
+        return value.initializer();
+    }
+
     override @property inout(TypeInfo) next() nothrow pure inout { return value; }
     override @property uint flags() nothrow pure const { return value.flags; }
 
@@ -661,7 +676,7 @@ class TypeInfo_AssociativeArray : TypeInfo
         return (char[int]).sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. (char[int]).sizeof];
     }
@@ -704,7 +719,11 @@ class TypeInfo_Vector : TypeInfo
 
     override @property inout(TypeInfo) next() nothrow pure inout { return base.next; }
     override @property uint flags() nothrow pure const { return base.flags; }
-    override const(void)[] init() nothrow pure const { return base.init(); }
+
+    override const(void)[] initializer() nothrow pure const
+    {
+        return base.initializer();
+    }
 
     override @property size_t talign() nothrow pure const { return 16; }
 
@@ -738,7 +757,7 @@ class TypeInfo_Function : TypeInfo
         return 0;       // no size for functions
     }
 
-    override const(void)[] init() const @safe
+    override const(void)[] initializer() const @safe
     {
         return null;
     }
@@ -793,7 +812,7 @@ class TypeInfo_Delegate : TypeInfo
         return dg.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. (int delegate()).sizeof];
     }
@@ -903,7 +922,10 @@ class TypeInfo_Class : TypeInfo
         return Object.sizeof;
     }
 
-    override const(void)[] init() nothrow pure const @safe { return m_init; }
+    override const(void)[] initializer() nothrow pure const @safe
+    {
+        return m_init;
+    }
 
     override @property uint flags() nothrow pure const { return 1; }
 
@@ -993,10 +1015,10 @@ unittest
         int a;
     }
 
-    assert(typeid(X).init is typeid(X).m_init);
-    assert(typeid(X).init.length == typeid(const(X)).init.length);
-    assert(typeid(X).init.length == typeid(shared(X)).init.length);
-    assert(typeid(X).init.length == typeid(immutable(X)).init.length);
+    assert(typeid(X).initializer is typeid(X).m_init);
+    assert(typeid(X).initializer.length == typeid(const(X)).initializer.length);
+    assert(typeid(X).initializer.length == typeid(shared(X)).initializer.length);
+    assert(typeid(X).initializer.length == typeid(immutable(X)).initializer.length);
 }
 
 class TypeInfo_Interface : TypeInfo
@@ -1058,7 +1080,7 @@ class TypeInfo_Interface : TypeInfo
         return Object.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. Object.sizeof];
     }
@@ -1078,7 +1100,7 @@ class TypeInfo_Struct : TypeInfo
             return true;
         auto s = cast(const TypeInfo_Struct)o;
         return s && this.name == s.name &&
-                    this.init().length == s.init().length;
+                    this.initializer().length == s.initializer().length;
     }
 
     override size_t getHash(in void* p) @safe pure nothrow const
@@ -1093,7 +1115,7 @@ class TypeInfo_Struct : TypeInfo
             import core.internal.traits : externDFunc;
             alias hashOf = externDFunc!("rt.util.hash.hashOf",
                                         size_t function(const(void)*, size_t, size_t) @trusted pure nothrow);
-            return hashOf(p, init().length, 0);
+            return hashOf(p, initializer().length, 0);
         }
     }
 
@@ -1109,7 +1131,7 @@ class TypeInfo_Struct : TypeInfo
             return true;
         else
             // BUG: relies on the GC not moving objects
-            return memcmp(p1, p2, init().length) == 0;
+            return memcmp(p1, p2, initializer().length) == 0;
     }
 
     override int compare(in void* p1, in void* p2) @trusted pure nothrow const
@@ -1127,7 +1149,7 @@ class TypeInfo_Struct : TypeInfo
                     return (*xopCmp)(p2, p1);
                 else
                     // BUG: relies on the GC not moving objects
-                    return memcmp(p1, p2, init().length);
+                    return memcmp(p1, p2, initializer().length);
             }
             else
                 return -1;
@@ -1137,10 +1159,13 @@ class TypeInfo_Struct : TypeInfo
 
     override @property size_t tsize() nothrow pure const
     {
-        return init().length;
+        return initializer().length;
     }
 
-    override const(void)[] init() nothrow pure const @safe { return m_init; }
+    override const(void)[] initializer() nothrow pure const @safe
+    {
+        return m_init;
+    }
 
     override @property uint flags() nothrow pure const { return m_flags; }
 
@@ -1164,7 +1189,7 @@ class TypeInfo_Struct : TypeInfo
     }
 
     string name;
-    void[] m_init;      // initializer; init.ptr == null if 0 initialize
+    void[] m_init;      // initializer; m_init.ptr == null if 0 initialize
 
   @safe pure nothrow
   {
@@ -1273,7 +1298,7 @@ class TypeInfo_Tuple : TypeInfo
         assert(0);
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         assert(0);
     }
@@ -1332,7 +1357,11 @@ class TypeInfo_Const : TypeInfo
 
     override @property inout(TypeInfo) next() nothrow pure inout { return base.next; }
     override @property uint flags() nothrow pure const { return base.flags; }
-    override const(void)[] init() nothrow pure const { return base.init(); }
+
+    override const(void)[] initializer() nothrow pure const
+    {
+        return base.initializer();
+    }
 
     override @property size_t talign() nothrow pure const { return base.talign; }
 
@@ -2729,7 +2758,7 @@ void destroy(T)(ref T obj) if (is(T == struct))
     _destructRecurse(obj);
     () @trusted {
         auto buf = (cast(ubyte*) &obj)[0 .. T.sizeof];
-        auto init = cast(ubyte[])typeid(T).init();
+        auto init = cast(ubyte[])typeid(T).initializer();
         if (init.ptr is null) // null ptr means initialize to 0s
             buf[] = 0;
         else

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -249,7 +249,7 @@ TypeInfo_Struct fakeEntryTI(const TypeInfo keyti, const TypeInfo valti)
     void* p = GC.malloc(sizeti + 2 * (void*).sizeof);
     import core.stdc.string : memcpy;
 
-    memcpy(p, typeid(TypeInfo_Struct).init().ptr, sizeti);
+    memcpy(p, typeid(TypeInfo_Struct).initializer().ptr, sizeti);
 
     auto ti = cast(TypeInfo_Struct) p;
     auto extra = cast(TypeInfo*)(p + sizeti);

--- a/src/rt/deh.d
+++ b/src/rt/deh.d
@@ -19,7 +19,7 @@ extern (C)
         auto t = cast(Throwable) o;
 
         if (t !is null && t.info is null &&
-            cast(byte*) t !is typeid(t).init.ptr)
+            cast(byte*) t !is typeid(t).initializer.ptr)
         {
             t.info = _d_traceContext(context);
         }

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -79,7 +79,7 @@ extern (C) Object _d_newclass(const ClassInfo ci)
          * function called by Release() when Release()'s reference count goes
          * to zero.
      */
-        p = malloc(ci.init.length);
+        p = malloc(ci.initializer.length);
         if (!p)
             onOutOfMemoryError();
     }
@@ -93,26 +93,26 @@ extern (C) Object _d_newclass(const ClassInfo ci)
             attr |= BlkAttr.FINALIZE;
         if (ci.m_flags & TypeInfo_Class.ClassFlags.noPointers)
             attr |= BlkAttr.NO_SCAN;
-        p = GC.malloc(ci.init.length, attr, ci);
+        p = GC.malloc(ci.initializer.length, attr, ci);
         debug(PRINTF) printf(" p = %p\n", p);
     }
 
     debug(PRINTF)
     {
         printf("p = %p\n", p);
-        printf("ci = %p, ci.init.ptr = %p, len = %llu\n", ci, ci.init.ptr, cast(ulong)ci.init.length);
-        printf("vptr = %p\n", *cast(void**) ci.init);
-        printf("vtbl[0] = %p\n", (*cast(void***) ci.init)[0]);
-        printf("vtbl[1] = %p\n", (*cast(void***) ci.init)[1]);
-        printf("init[0] = %x\n", (cast(uint*) ci.init)[0]);
-        printf("init[1] = %x\n", (cast(uint*) ci.init)[1]);
-        printf("init[2] = %x\n", (cast(uint*) ci.init)[2]);
-        printf("init[3] = %x\n", (cast(uint*) ci.init)[3]);
-        printf("init[4] = %x\n", (cast(uint*) ci.init)[4]);
+        printf("ci = %p, ci.init.ptr = %p, len = %llu\n", ci, ci.initializer.ptr, cast(ulong)ci.initializer.length);
+        printf("vptr = %p\n", *cast(void**) ci.initializer);
+        printf("vtbl[0] = %p\n", (*cast(void***) ci.initializer)[0]);
+        printf("vtbl[1] = %p\n", (*cast(void***) ci.initializer)[1]);
+        printf("init[0] = %x\n", (cast(uint*) ci.initializer)[0]);
+        printf("init[1] = %x\n", (cast(uint*) ci.initializer)[1]);
+        printf("init[2] = %x\n", (cast(uint*) ci.initializer)[2]);
+        printf("init[3] = %x\n", (cast(uint*) ci.initializer)[3]);
+        printf("init[4] = %x\n", (cast(uint*) ci.initializer)[4]);
     }
 
     // initialize it
-    p[0 .. ci.init.length] = ci.init[];
+    p[0 .. ci.initializer.length] = ci.initializer[];
 
     debug(PRINTF) printf("initialization done\n");
     return cast(Object) p;
@@ -959,7 +959,7 @@ extern (C) void[] _d_newarrayiT(const TypeInfo ti, size_t length) pure nothrow
     auto tinext = unqualify(ti.next);
     auto size = tinext.tsize;
 
-    auto init = tinext.init();
+    auto init = tinext.initializer();
 
     switch (init.length)
     {
@@ -1087,7 +1087,7 @@ extern (C) void* _d_newitemT(in TypeInfo _ti)
 extern (C) void* _d_newitemiT(in TypeInfo _ti)
 {
     auto p = _d_newitemU(_ti);
-    auto init = _ti.init();
+    auto init = _ti.initializer();
     assert(init.length <= _ti.tsize);
     memcpy(p, init.ptr, init.length);
     return p;
@@ -1376,7 +1376,7 @@ extern (C) void rt_finalize2(void* p, bool det = true, bool resetMemory = true) 
 
         if (resetMemory)
         {
-            auto w = (*pc).init;
+            auto w = (*pc).initializer;
             p[0 .. w.length] = w[];
         }
     }
@@ -1604,7 +1604,7 @@ body
     void* newdata;
     auto tinext = unqualify(ti.next);
     auto sizeelem = tinext.tsize;
-    auto initializer = tinext.init();
+    auto initializer = tinext.initializer();
     auto initsize = initializer.length;
 
     assert(sizeelem);

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -341,7 +341,7 @@ extern(C) void _d_dso_registry(CompilerDSOData* data)
         if (firstDSO) initLocks();
 
         DSO* pdso = cast(DSO*).calloc(1, DSO.sizeof);
-        assert(typeid(DSO).init().ptr is null);
+        assert(typeid(DSO).initializer().ptr is null);
         *data._slot = pdso; // store backlink in library record
 
         pdso._moduleGroup = ModuleGroup(toRange(data._minfo_beg, data._minfo_end));

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -102,7 +102,7 @@ extern (C) Object _d_newclassTrace(string file, int line, string funcname, const
             funcname.length, funcname.ptr
             );
     }
-    accumulate(file, line, funcname, ci.name, ci.init.length);
+    accumulate(file, line, funcname, ci.name, ci.initializer.length);
     return _d_newclass(ci);
 }
 

--- a/src/rt/typeinfo/ti_C.d
+++ b/src/rt/typeinfo/ti_C.d
@@ -63,7 +63,7 @@ class TypeInfo_C : TypeInfo
         return Object.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. Object.sizeof];
     }

--- a/src/rt/typeinfo/ti_byte.d
+++ b/src/rt/typeinfo/ti_byte.d
@@ -44,7 +44,7 @@ class TypeInfo_g : TypeInfo
         return byte.sizeof;
     }
 
-    override const(void)[] init() @trusted
+    override const(void)[] initializer() @trusted
     {
         return (cast(void *)null)[0 .. byte.sizeof];
     }

--- a/src/rt/typeinfo/ti_cdouble.d
+++ b/src/rt/typeinfo/ti_cdouble.d
@@ -54,7 +54,7 @@ class TypeInfo_r : TypeInfo
         *cast(F*)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable F r;
         return (&r)[0 .. 1];

--- a/src/rt/typeinfo/ti_cent.d
+++ b/src/rt/typeinfo/ti_cent.d
@@ -52,7 +52,7 @@ class TypeInfo_zi : TypeInfo
         return cent.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. cent.sizeof];
     }

--- a/src/rt/typeinfo/ti_cfloat.d
+++ b/src/rt/typeinfo/ti_cfloat.d
@@ -54,7 +54,7 @@ class TypeInfo_q : TypeInfo
         *cast(F*)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable F r;
         return (&r)[0 .. 1];

--- a/src/rt/typeinfo/ti_char.d
+++ b/src/rt/typeinfo/ti_char.d
@@ -53,7 +53,7 @@ class TypeInfo_a : TypeInfo
         *cast(char *)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable char c;
 

--- a/src/rt/typeinfo/ti_creal.d
+++ b/src/rt/typeinfo/ti_creal.d
@@ -54,7 +54,7 @@ class TypeInfo_c : TypeInfo
         *cast(F*)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable F r;
         return (&r)[0 .. 1];

--- a/src/rt/typeinfo/ti_dchar.d
+++ b/src/rt/typeinfo/ti_dchar.d
@@ -53,7 +53,7 @@ class TypeInfo_w : TypeInfo
         *cast(dchar *)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable dchar c;
 

--- a/src/rt/typeinfo/ti_delegate.d
+++ b/src/rt/typeinfo/ti_delegate.d
@@ -50,7 +50,7 @@ class TypeInfo_D : TypeInfo
         *cast(dg *)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable dg d;
 

--- a/src/rt/typeinfo/ti_double.d
+++ b/src/rt/typeinfo/ti_double.d
@@ -54,7 +54,7 @@ class TypeInfo_d : TypeInfo
         *cast(F*)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable F r;
         return (&r)[0 .. 1];

--- a/src/rt/typeinfo/ti_float.d
+++ b/src/rt/typeinfo/ti_float.d
@@ -54,7 +54,7 @@ class TypeInfo_f : TypeInfo
         *cast(F*)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable F r;
         return (&r)[0 .. 1];

--- a/src/rt/typeinfo/ti_int.d
+++ b/src/rt/typeinfo/ti_int.d
@@ -48,7 +48,7 @@ class TypeInfo_i : TypeInfo
         return int.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. int.sizeof];
     }

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -50,7 +50,7 @@ class TypeInfo_l : TypeInfo
         return long.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. long.sizeof];
     }

--- a/src/rt/typeinfo/ti_ptr.d
+++ b/src/rt/typeinfo/ti_ptr.d
@@ -48,7 +48,7 @@ class TypeInfo_P : TypeInfo
         return (void*).sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. (void*).sizeof];
     }

--- a/src/rt/typeinfo/ti_real.d
+++ b/src/rt/typeinfo/ti_real.d
@@ -54,7 +54,7 @@ class TypeInfo_e : TypeInfo
         *cast(F*)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable F r;
         return (&r)[0 .. 1];

--- a/src/rt/typeinfo/ti_short.d
+++ b/src/rt/typeinfo/ti_short.d
@@ -44,7 +44,7 @@ class TypeInfo_s : TypeInfo
         return short.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. short.sizeof];
     }

--- a/src/rt/typeinfo/ti_ubyte.d
+++ b/src/rt/typeinfo/ti_ubyte.d
@@ -44,7 +44,7 @@ class TypeInfo_h : TypeInfo
         return ubyte.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. ubyte.sizeof];
     }

--- a/src/rt/typeinfo/ti_ucent.d
+++ b/src/rt/typeinfo/ti_ucent.d
@@ -52,7 +52,7 @@ class TypeInfo_zk : TypeInfo
         return ucent.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. ucent.sizeof];
     }

--- a/src/rt/typeinfo/ti_uint.d
+++ b/src/rt/typeinfo/ti_uint.d
@@ -48,7 +48,7 @@ class TypeInfo_k : TypeInfo
         return uint.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. uint.sizeof];
     }

--- a/src/rt/typeinfo/ti_ulong.d
+++ b/src/rt/typeinfo/ti_ulong.d
@@ -50,7 +50,7 @@ class TypeInfo_m : TypeInfo
         return ulong.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. ulong.sizeof];
     }

--- a/src/rt/typeinfo/ti_ushort.d
+++ b/src/rt/typeinfo/ti_ushort.d
@@ -44,7 +44,7 @@ class TypeInfo_t : TypeInfo
         return ushort.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. ushort.sizeof];
     }

--- a/src/rt/typeinfo/ti_void.d
+++ b/src/rt/typeinfo/ti_void.d
@@ -44,7 +44,7 @@ class TypeInfo_v : TypeInfo
         return void.sizeof;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         return (cast(void *)null)[0 .. void.sizeof];
     }

--- a/src/rt/typeinfo/ti_wchar.d
+++ b/src/rt/typeinfo/ti_wchar.d
@@ -53,7 +53,7 @@ class TypeInfo_u : TypeInfo
         *cast(wchar *)p2 = t;
     }
 
-    override const(void)[] init() const @trusted
+    override const(void)[] initializer() const @trusted
     {
         static immutable wchar c;
 

--- a/src/rt/util/container/common.d
+++ b/src/rt/util/container/common.d
@@ -45,7 +45,7 @@ void destroy(T)(ref T t) if (!is(T == struct))
 void initialize(T)(ref T t) if (is(T == struct))
 {
     import core.stdc.string;
-    if(auto p = typeid(T).init().ptr)
+    if(auto p = typeid(T).initializer().ptr)
         memcpy(&t, p, T.sizeof);
     else
         memset(&t, 0, T.sizeof);


### PR DESCRIPTION
"init" clashes with the type property of the same name.

Adding a deprecated alias called "init" to give people a chance to
update their code. Planning to remove the alias in 2.071 to fix issue
12233.

~~https://issues.dlang.org/show_bug.cgi?id=15037~~
https://issues.dlang.org/show_bug.cgi?id=12233