### PR TITLE
forgot to add timerfd to the makefile

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -64,8 +64,10 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\execinfo.d \
 	$(IMPDIR)\core\sys\linux\fcntl.d \
 	$(IMPDIR)\core\sys\linux\link.d \
+	$(IMPDIR)\core\sys\linux\stdio.d \
 	$(IMPDIR)\core\sys\linux\termios.d \
 	$(IMPDIR)\core\sys\linux\time.d \
+	$(IMPDIR)\core\sys\linux\timerfd.d \
 	$(IMPDIR)\core\sys\linux\tipc.d \
 	$(IMPDIR)\core\sys\linux\unistd.d \
 	\

--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -94,6 +94,7 @@ MANIFEST=\
 	src\core\sys\linux\stdio.d \
 	src\core\sys\linux\termios.d \
 	src\core\sys\linux\time.d \
+	src\core\sys\linux\timerfd.d \
 	src\core\sys\linux\tipc.d \
 	\
 	src\core\sys\linux\sys\inotify.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -48,7 +48,9 @@ SRCS=\
 	src\core\sys\freebsd\execinfo.d \
 	src\core\sys\freebsd\sys\event.d \
 	\
+	src\core\sys\linux\epoll.d \
 	src\core\sys\linux\stdio.d \
+	src\core\sys\linux\timerfd.d \
 	src\core\sys\linux\tipc.d \
 	\
 	src\core\sys\posix\signal.d \


### PR DESCRIPTION
The druntime build system is error-prone. Having to duplicate the file names over so many places when it really should just do something like *.d means these things are forgotten and almost slip by the beta unnoticed!

Without this, the file is never copied from src/ over to import/ (why does it even use separate folders for that anyway? pointless waste of time), nor is the init blob included in the object file, meaning the structs need to be void initialized to avoid linker errors! (I noticed that with epoll too and shoved its line in here too.)

I recommend these makefiles be rewritten. I knew the Windows one was laughably bad, but I didn't realize the posix one made many of the same mistakes. But until then, this keeps my new addition from being broken on new installs.