### PR TITLE
fix Issue 14993 - segfault for InvalidMemoryOperationError

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -130,6 +130,7 @@ class FinalizeError : Error
     this( TypeInfo ci, string file = __FILE__, size_t line = __LINE__, Throwable next = null ) @safe pure nothrow @nogc
     {
         super( "Finalization error", file, line, next );
+        super.info = SuppressTraceInfo.instance;
         info = ci;
     }
 
@@ -214,7 +215,14 @@ class OutOfMemoryError : Error
 {
     this(string file = __FILE__, size_t line = __LINE__, Throwable next = null ) @safe pure nothrow @nogc
     {
-        super( "Memory allocation failed", file, line, next );
+        this(true, file, line, next);
+    }
+
+    this(bool trace, string file = __FILE__, size_t line = __LINE__, Throwable next = null ) @safe pure nothrow @nogc
+    {
+        super("Memory allocation failed", file, line, next);
+        if (!trace)
+            this.info = SuppressTraceInfo.instance;
     }
 
     override string toString() const @trusted
@@ -256,6 +264,7 @@ class InvalidMemoryOperationError : Error
     this(string file = __FILE__, size_t line = __LINE__, Throwable next = null ) @safe pure nothrow @nogc
     {
         super( "Invalid memory operation", file, line, next );
+        this.info = SuppressTraceInfo.instance;
     }
 
     override string toString() const @trusted
@@ -519,6 +528,12 @@ extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure
     throw staticError!OutOfMemoryError();
 }
 
+extern (C) void onOutOfMemoryErrorNoGC() @trusted nothrow @nogc
+{
+    // suppress stacktrace until they are @nogc
+    throw staticError!OutOfMemoryError(false);
+}
+
 
 /**
  * A callback for invalid memory operations in D.  An
@@ -663,4 +678,18 @@ private T staticError(T, Args...)(auto ref Args args)
     auto res = (cast(T function() @trusted pure nothrow @nogc) &get)();
     res.__ctor(args);
     return res;
+}
+
+// Suppress traceinfo generation when the GC cannot be used.  Workaround for
+// Bugzilla 14993. We should make stack traces @nogc instead.
+private class SuppressTraceInfo : Throwable.TraceInfo
+{
+    override int opApply(scope int delegate(ref const(char[]))) const { return 0; }
+    override int opApply(scope int delegate(ref size_t, ref const(char[]))) const { return 0; }
+    override string toString() const { return null; }
+    static SuppressTraceInfo instance() @trusted @nogc pure nothrow
+    {
+        static immutable SuppressTraceInfo it = new SuppressTraceInfo;
+        return cast(SuppressTraceInfo)it;
+    }
 }

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -2571,16 +2571,13 @@ unittest
         import core.exception;
         static class C1
         {
-            // preallocate to not call new in destructor
-            __gshared E exc = new E("test onFinalizeError");
-            ~this()
-            {
-                throw exc;
-            }
+            E exc;
+            this(E exc) { this.exc = exc; }
+            ~this() { throw exc; }
         }
 
         bool caught = false;
-        C1 c = new C1;
+        C1 c = new C1(new E("test onFinalizeError"));
         try
         {
             GC.runFinalizers((cast(uint*)&C1.__dtor)[0..1]);
@@ -2613,16 +2610,12 @@ unittest
         import core.exception;
         static struct S1
         {
-            // preallocate to not call new in destructor
-            __gshared E exc = new E("test onFinalizeError");
-            ~this()
-            {
-                throw exc;
-            }
+            E exc;
+            ~this() { throw exc; }
         }
 
         bool caught = false;
-        S1* s = new S1;
+        S1* s = new S1(new E("test onFinalizeError"));
         try
         {
             GC.runFinalizers((cast(char*)(typeid(S1).xdtor))[0..1]);

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=stderr_msg unittest_assert
+TESTS:=stderr_msg unittest_assert invalid_memory_operation
 ifeq ($(OS)-$(BUILD),linux-debug)
 	TESTS:=$(TESTS) line_trace
 endif
@@ -14,26 +14,19 @@ SED:=sed
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
-$(ROOT)/%.done: $(ROOT)/%
-	@echo Testing $*
-	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
-	@touch $@
-
-$(ROOT)/stderr_msg.done: $(ROOT)/stderr_msg
-	@echo Testing stderr_msg
-	$(QUIET)./$(ROOT)/stderr_msg $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF "stderr_msg msg"
-	@touch $@
-
-$(ROOT)/unittest_assert.done: $(ROOT)/unittest_assert
-	@echo Testing unittest_assert
-	$(QUIET)./$(ROOT)/unittest_assert $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF "unittest_assert msg"
-	@touch $@
-
 $(ROOT)/line_trace.done: $(ROOT)/line_trace
 	@echo Testing line_trace
-	@rm -f $(ROOT)/line_trace.output
-	$(QUIET)./$(ROOT)/line_trace $(RUN_ARGS) > $(ROOT)/line_trace.output
+	$(QUIET)$(ROOT)/line_trace $(RUN_ARGS) > $(ROOT)/line_trace.output
 	$(QUIET)$(SED) "s/\[0x[0-9a-f]*\]/\[ADDR\]/g" $(ROOT)/line_trace.output | $(DIFF) line_trace.exp -
+	@rm -f $(ROOT)/line_trace.output
+	@touch $@
+
+$(ROOT)/stderr_msg.done: STDERR_EXP="stderr_msg msg"
+$(ROOT)/unittest_assert.done: STDERR_EXP="unittest_assert msg"
+$(ROOT)/invalid_memory_operation.done: STDERR_EXP="InvalidMemoryOperationError"
+$(ROOT)/%.done: $(ROOT)/%
+	@echo Testing $*
+	$(QUIET)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
 	@touch $@
 
 $(ROOT)/unittest_assert: DFLAGS+=-unittest

--- a/test/exceptions/src/invalid_memory_operation.d
+++ b/test/exceptions/src/invalid_memory_operation.d
@@ -1,0 +1,12 @@
+struct S
+{
+    ~this()
+    {
+        new int;
+    }
+}
+
+void main()
+{
+    new S;
+}


### PR DESCRIPTION
- creating a stacktrace currently uses the GC (thus might recurse
  infinetely when the GC throws an exception itself)
- suppress stack traces for OutOfMemoryError,
  InvalidMemoryOperationError, and FinalizeError

[Issue 14993 – Allocating in a destructor segfaults instead of throwing InvalidMemoryOperationError](https://issues.dlang.org/show_bug.cgi?id=14993)