### PR TITLE
issue 14327: move call to init_msvc() into rt_init()

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -164,6 +164,9 @@ extern (C) int rt_init()
        rt_init. */
     if (atomicOp!"+="(_initCount, 1) > 1) return 1;
 
+    version (CRuntime_Microsoft)
+        init_msvc();
+
     _d_monitor_staticctor();
     _d_critical_init();
 
@@ -325,8 +328,6 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
     }
     version (CRuntime_Microsoft)
     {
-        init_msvc();
-
         // enable full precision for reals
         version(Win64)
             asm

--- a/test/exceptions/line_trace.exp
+++ b/test/exceptions/line_trace.exp
@@ -2,8 +2,8 @@ object.Exception@src/line_trace.d(17): exception
 ----------------
 src/line_trace.d:17 void line_trace.f1() [ADDR]
 src/line_trace.d:5 _Dmain [ADDR]
-src/rt/dmain2.d:471 _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv [ADDR]
-src/rt/dmain2.d:446 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [ADDR]
-src/rt/dmain2.d:471 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [ADDR]
-src/rt/dmain2.d:446 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [ADDR]
-src/rt/dmain2.d:479 _d_run_main [ADDR]
+src/rt/dmain2.d:472 _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv [ADDR]
+src/rt/dmain2.d:447 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [ADDR]
+src/rt/dmain2.d:472 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [ADDR]
+src/rt/dmain2.d:447 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [ADDR]
+src/rt/dmain2.d:480 _d_run_main [ADDR]


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14327

stdin,stdout,stderr handles are only initialized when running d_run_main, but not rt_init.