### PR TITLE
core.thread: Only use pthread to store Thread.sm_this when building shared library

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -41,6 +41,12 @@ version( Solaris )
 // this should be true for most architectures
 version = StackGrowsDown;
 
+// On Posix (excluding OSX), pthread_key_t is explicitly used to
+// store and access thread reference. This is needed
+// to avoid TLS access in signal handlers (malloc deadlock)
+// when using shared libraries, see issue 11981.
+version ( Posix ) version ( Shared ) version = UsePthreadTlsForThreadThis;
+
 /**
  * Returns the process ID of the calling process, which is guaranteed to be
  * unique on the system. This call is always successful.
@@ -1151,7 +1157,7 @@ class Thread
         {
             return sm_this;
         }
-        else version( Posix )
+        else version( UsePthreadTlsForThreadThis )
         {
             auto t = cast(Thread) pthread_getspecific( sm_this );
             return t;
@@ -1385,12 +1391,8 @@ private:
     {
         static Thread       sm_this;
     }
-    else version( Posix )
+    else version( UsePthreadTlsForThreadThis )
     {
-        // On Posix (excluding OSX), pthread_key_t is explicitly used to
-        // store and access thread reference. This is needed
-        // to avoid TLS access in signal handlers (malloc deadlock)
-        // when using shared libraries, see issue 11981.
         __gshared pthread_key_t sm_this;
     }
     else
@@ -1459,7 +1461,7 @@ private:
         {
             sm_this = t;
         }
-        else version( Posix )
+        else version( UsePthreadTlsForThreadThis )
         {
             pthread_setspecific( sm_this, cast(void*) t );
         }
@@ -1999,8 +2001,11 @@ extern (C) void thread_init()
         status = sem_init( &suspendCount, 0, 0 );
         assert( status == 0 );
 
-        status = pthread_key_create( &Thread.sm_this, null );
-        assert( status == 0 );
+        version( UsePthreadTlsForThreadThis )
+        {
+            status = pthread_key_create( &Thread.sm_this, null );
+            assert( status == 0 );
+        }
     }
     Thread.sm_main = thread_attachThis();
 }
@@ -2017,7 +2022,7 @@ extern (C) void thread_term()
     version( OSX )
     {
     }
-    else version( Posix )
+    else version( UsePthreadTlsForThreadThis )
     {
         pthread_key_delete( Thread.sm_this );
     }


### PR DESCRIPTION
This avoids calling into pthread on switching fiber contexts
with a static runtime, which can be (comparatively) very
expensive (taking a kernel spinlock).