### PR TITLE
fix Issue 15268 - deadlock for Thread.getAll/Thread.opApply

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -682,7 +682,7 @@ private T staticError(T, Args...)(auto ref Args args)
 
 // Suppress traceinfo generation when the GC cannot be used.  Workaround for
 // Bugzilla 14993. We should make stack traces @nogc instead.
-private class SuppressTraceInfo : Throwable.TraceInfo
+package class SuppressTraceInfo : Throwable.TraceInfo
 {
     override int opApply(scope int delegate(ref const(char[]))) const { return 0; }
     override int opApply(scope int delegate(ref size_t, ref const(char[]))) const { return 0; }

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -271,11 +271,8 @@ else version( Posix )
             //Thread.add( obj );
             scope( exit )
             {
-                // NOTE: isRunning should be set to false after the thread is
-                //       removed or a double-removal could occur between this
-                //       function and thread_suspendAll.
                 Thread.remove( obj );
-                atomicStore!(MemoryOrder.raw)(obj.m_isRunning,false);
+                atomicStore!(MemoryOrder.raw)(obj.m_isRunning, false);
             }
             Thread.add( &obj.m_main );
 
@@ -2012,6 +2009,7 @@ extern (C) void thread_init()
  */
 extern (C) void thread_term()
 {
+    assert(Thread.sm_tbeg && Thread.sm_tlen == 1);
     Thread.termLocks();
 
     version( OSX )


### PR DESCRIPTION
- fix a deadlock caused by lock order inversion
- must not use the GC while holding slock