### PR TITLE
Add clock definitions for Solaris.

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -139,6 +139,7 @@ COPY=\
 	$(IMPDIR)\core\sys\solaris\execinfo.d \
 	$(IMPDIR)\core\sys\solaris\libelf.d \
 	$(IMPDIR)\core\sys\solaris\link.d \
+	$(IMPDIR)\core\sys\solaris\time.d \
 	$(IMPDIR)\core\sys\solaris\sys\elf.d \
 	$(IMPDIR)\core\sys\solaris\sys\elf_386.d \
 	$(IMPDIR)\core\sys\solaris\sys\elf_amd64.d \

--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -170,6 +170,7 @@ MANIFEST=\
 	src\core\sys\solaris\execinfo.d \
 	src\core\sys\solaris\libelf.d \
 	src\core\sys\solaris\link.d \
+	src\core\sys\solaris\time.d \
 	\
 	src\core\sys\solaris\sys\elf.d \
 	src\core\sys\solaris\sys\elf_386.d \

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -247,13 +247,16 @@ else version( FreeBSD )
 }
 else version (Solaris)
 {
+    enum CLOCK_PROCESS_CPUTIME_ID = 5; // <sys/time_impl.h>
+    enum CLOCK_THREAD_CPUTIME_ID  = 2; // <sys/time_impl.h>
+
     struct itimerspec
     {
         timespec it_interval;
         timespec it_value;
     }
 
-    enum CLOCK_REALTIME = 0; // <sys/time_impl.h>
+    enum CLOCK_REALTIME = 3; // <sys/time_impl.h>
     enum TIMER_ABSOLUTE = 0x1;
 
     alias int clockid_t;

--- a/src/core/sys/solaris/time.d
+++ b/src/core/sys/solaris/time.d
@@ -1,0 +1,18 @@
+//Written in the D programming language
+
+/++
+    D header file for Solaris's extensions to POSIX's time.h.
+
+    Copyright: Copyright 2014
+    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   Kai Nacke
+ +/
+module core.sys.solaris.time;
+
+public import core.sys.posix.time;
+
+version(Solaris):
+
+enum CLOCK_VIRTUAL           = 1;
+enum CLOCK_HIGHRES           = CLOCK_MONOTONIC;
+enum CLOCK_PROF              = CLOCK_THREAD_CPUTIME_ID;

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -206,7 +206,7 @@ version(CoreDdoc) enum ClockType
     precise = 3,
 
     /++
-        $(BLUE Linux-Only)
+        $(BLUE Linux,Solaris-Only)
 
         Uses $(D CLOCK_PROCESS_CPUTIME_ID).
       +/
@@ -243,7 +243,7 @@ version(CoreDdoc) enum ClockType
     second = 6,
 
     /++
-        $(BLUE Linux-Only)
+        $(BLUE Linux,Solaris-Only)
 
         Uses $(D CLOCK_THREAD_CPUTIME_ID).
       +/
@@ -305,6 +305,15 @@ else version(FreeBSD) enum ClockType
     uptimeCoarse = 9,
     uptimePrecise = 10,
 }
+else version(Solaris) enum ClockType
+{
+    normal = 0,
+    coarse = 2,
+    precise = 3,
+    processCPUTime = 4,
+    second = 6,
+    threadCPUTime = 7,
+}
 else
 {
     // It needs to be decided (and implemented in an appropriate version branch
@@ -348,6 +357,19 @@ version(Posix)
             case uptime: return CLOCK_UPTIME;
             case uptimeCoarse: return CLOCK_UPTIME_FAST;
             case uptimePrecise: return CLOCK_UPTIME_PRECISE;
+            case second: assert(0);
+            }
+        }
+        else version(Solaris)
+        {
+            import core.sys.solaris.time;
+            with(ClockType) final switch(clockType)
+            {
+            case coarse: return CLOCK_MONOTONIC;
+            case normal: return CLOCK_MONOTONIC;
+            case precise: return CLOCK_MONOTONIC;
+            case processCPUTime: return CLOCK_PROCESS_CPUTIME_ID;
+            case threadCPUTime: return CLOCK_THREAD_CPUTIME_ID;
             case second: assert(0);
             }
         }

--- a/win32.mak
+++ b/win32.mak
@@ -592,6 +592,9 @@ $(IMPDIR)\core\sys\solaris\libelf.d : src\core\sys\solaris\libelf.d
 $(IMPDIR)\core\sys\solaris\link.d : src\core\sys\solaris\link.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\solaris\time.d : src\core\sys\solaris\time.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\solaris\sys\elf.d : src\core\sys\solaris\sys\elf.d
 	copy $** $@
 

--- a/win64.mak
+++ b/win64.mak
@@ -602,6 +602,9 @@ $(IMPDIR)\core\sys\solaris\libelf.d : src\core\sys\solaris\libelf.d
 $(IMPDIR)\core\sys\solaris\link.d : src\core\sys\solaris\link.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\solaris\time.d : src\core\sys\solaris\time.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\solaris\sys\elf.d : src\core\sys\solaris\sys\elf.d
 	copy $** $@
 


### PR DESCRIPTION
Required to compile druntime on OpenSolaris 11.2.