### PR TITLE
Add strerror_r() for OpenSolaris.

### DIFF
--- a/src/core/stdc/string.d
+++ b/src/core/stdc/string.d
@@ -80,6 +80,10 @@ else version (FreeBSD)
 {
     int strerror_r(int errnum, char* buf, size_t buflen);
 }
+else version (Solaris)
+{
+    int strerror_r(int errnum, char* buf, size_t buflen);
+}
 else version (CRuntime_Bionic)
 {
     ///


### PR DESCRIPTION
Required to compile Phobos on OpenSolaris.