### PR TITLE
Fix issue 15334 - OS X core.time ticksPerSecond calculation is incorrect

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2682,18 +2682,14 @@ extern(C) void _d_initMonoTime()
     }
     else version(OSX)
     {
-        mach_timebase_info_data_t info;
-        if(mach_timebase_info(&info) == 0)
+        immutable long ticksPerSecond = machTicksPerSecond();
+        foreach(i, typeStr; __traits(allMembers, ClockType))
         {
-            long ticksPerSecond = 1_000_000_000L * info.numer / info.denom;
-            foreach(i, typeStr; __traits(allMembers, ClockType))
-            {
-                // ensure we are only writing immutable data once
-                if(tps[i] != 0)
-                    // should only be called once
-                    assert(0);
-                tps[i] = ticksPerSecond;
-            }
+            // ensure we are only writing immutable data once
+            if(tps[i] != 0)
+                // should only be called once
+                assert(0);
+            tps[i] = ticksPerSecond;
         }
     }
     else version(Posix)
@@ -2993,17 +2989,7 @@ struct TickDuration
         }
         else version(OSX)
         {
-            static if(is(typeof(mach_absolute_time)))
-            {
-                mach_timebase_info_data_t info;
-
-                if(mach_timebase_info(&info))
-                    ticksPerSec = 0;
-                else
-                    ticksPerSec = (1_000_000_000L * info.denom) / info.numer;
-            }
-            else
-                ticksPerSec = 1_000_000;
+            ticksPerSec = machTicksPerSecond();
         }
         else version(Posix)
         {
@@ -4732,6 +4718,21 @@ unittest
     static assert(!__traits(compiles, nextLargerTimeUnits!"years"));
 }
 
+version(OSX)
+long machTicksPerSecond()
+{
+    // Be optimistic that ticksPerSecond (1e9*denom/numer) is integral. So far
+    // so good on Darwin based platforms OS X, iOS.
+    import core.internal.abort : abort;
+    mach_timebase_info_data_t info;
+    if(mach_timebase_info(&info) != 0)
+        abort("Failed in mach_timebase_info().");
+
+    long scaledDenom = 1_000_000_000L * info.denom;
+    if(scaledDenom % info.numer != 0)
+        abort("Non integral ticksPerSecond from mach_timebase_info.");
+    return scaledDenom / info.numer;
+}
 
 /+
     Local version of abs, since std.math.abs is in Phobos, not druntime.


### PR DESCRIPTION
Fix for https://issues.dlang.org/show_bug.cgi?id=15334

The `_d_initMonoTime()` `version(OSX)` calculation for ticksPerSecond is using a flipped mach_timebase_info ratio numer/denom when it should be denom/numer.

This is a redo of #1430 on stable per @schveiguy with some of his suggestions.