### PR TITLE
OS X - Use 64-bit inode stat and dirent functions

### DIFF
--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -632,40 +632,39 @@ version( CRuntime_Glibc )
 }
 else version( OSX )
 {
+    // _DARWIN_FEATURE_64_BIT_INODE stat is default for Mac OSX >10.5 and is
+    // only meaningful type for other OS X/Darwin variants (e.g. iOS).
+    // man stat(2) gives details.
     struct stat_t
     {
-      version ( DARWIN_USE_64_BIT_INODE )
-      {
         dev_t       st_dev;
         mode_t      st_mode;
         nlink_t     st_nlink;
         ino_t       st_ino;
-      }
-      else
-      {
-        dev_t       st_dev;
-        ino_t       st_ino;
-        mode_t      st_mode;
-        nlink_t     st_nlink;
-      }
         uid_t       st_uid;
         gid_t       st_gid;
         dev_t       st_rdev;
-      static if( false /*!_POSIX_C_SOURCE || _DARWIN_C_SOURCE*/ )
-      {
-          timespec  st_atimespec;
-          timespec  st_mtimespec;
-          timespec  st_ctimespec;
-      }
-      else
-      {
-        time_t      st_atime;
-        c_long      st_atimensec;
-        time_t      st_mtime;
-        c_long      st_mtimensec;
-        time_t      st_ctime;
-        c_long      st_ctimensec;
-      }
+        union
+        {
+            struct
+            {
+                timespec  st_atimespec;
+                timespec  st_mtimespec;
+                timespec  st_ctimespec;
+                timespec  st_birthtimespec;
+            }
+            struct
+            {
+                time_t      st_atime;
+                c_long      st_atimensec;
+                time_t      st_mtime;
+                c_long      st_mtimensec;
+                time_t      st_ctime;
+                c_long      st_ctimensec;
+                time_t      st_birthtime;
+                c_long      st_birthtimensec;
+            }
+        }
         off_t       st_size;
         blkcnt_t    st_blocks;
         blksize_t   st_blksize;
@@ -1095,9 +1094,11 @@ else version (Solaris)
 }
 else version( OSX )
 {
-    int   fstat(int, stat_t*);
-    int   lstat(in char*, stat_t*);
-    int   stat(in char*, stat_t*);
+    // OS X maintains backwards compatibility with older binaries using 32-bit
+    // inode functions by appending $INODE64 to newer 64-bit inode functions.
+    pragma(mangle, "fstat$INODE64") int fstat(int, stat_t*);
+    pragma(mangle, "lstat$INODE64") int lstat(in char*, stat_t*);
+    pragma(mangle, "stat$INODE64")  int stat(in char*, stat_t*);
 }
 else version( FreeBSD )
 {

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -107,11 +107,7 @@ else version( OSX )
     alias int       blksize_t;
     alias int       dev_t;
     alias uint      gid_t;
-    version( DARWIN_USE_64_BIT_INODE ) {
-        alias ulong ino_t;
-    } else {
-        alias uint  ino_t;
-    }
+    alias ulong     ino_t;
     alias ushort    mode_t;
     alias ushort    nlink_t;
     alias long      off_t;


### PR DESCRIPTION
This updates the stat and dirent family of types and functions (dirent.h and sys/stat.h) to use the newer 64-bit inode versions.  These functions are the default for C compiled code on OS X > 10.5 and provide extra fields and longer filenames.

This also removes the 32-bit inode versions as I believe they are intended for compatibility with binaries build pre 64-bit inode OS X.  I would think all new code should use 64-bit inode versions.

But just in case that isn't preferred, I do have two other versions of this PR that allows:
- selection of 64-bit or 32-bit, configurable at compile time, or
- both 64-bit and 32-bit coexist, where 32-bit is selected by `import core.sys.osx.sys.stat_ino32`