### PR TITLE
use DDSUBLINK instead of LINK2

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -848,7 +848,7 @@ unittest
 /**
  * Runtime type information about a class.
  * Can be retrieved from an object instance by using the
- * $(LINK2 ../spec/property.html#classinfo, .classinfo) property.
+ * $(DDSUBLINK spec/property,classinfo, .classinfo) property.
  */
 class TypeInfo_Class : TypeInfo
 {


### PR DESCRIPTION
DDSUBLINK uses ROOT_DIR which is more robust than a relative path.

Together with https://github.com/D-Programming-Language/dlang.org/pull/1159 this fixes the link in the online DDox docs.