### PR TITLE
Add message() to object.Throwable

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1607,6 +1607,7 @@ class Throwable : Object
         sink("@"); sink(file);
         sink("("); sink(sizeToTempString(line, tmpBuff, 10)); sink(")");
 
+        auto msg = message();
         if (msg.length)
         {
             sink(": "); sink(msg);
@@ -1626,6 +1627,19 @@ class Throwable : Object
                 // ignore more errors
             }
         }
+    }
+
+    /**
+     * Get the message describing the error.
+     * Base behavior is to return the `Throwable.msg` field.
+     * Override to return some other error message.
+     *
+     * Returns:
+     *  message
+     */
+    const(char)[] message() const
+    {
+        return msg;
     }
 }
 


### PR DESCRIPTION
Having `msg` as a user accessible field turns out to make customized exceptions more difficult than they should be. Turning it into a property function can break existing code. So added an overridable `message` function instead, and undocumented `msg`.