### PR TITLE
MSVC: Provide alternate implementations for 32-bit math functions

### DIFF
--- a/src/rt/msvc.c
+++ b/src/rt/msvc.c
@@ -6,7 +6,7 @@
 * License: Distributed under the
 *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
 *    (See accompanying file LICENSE)
-* Source:    $(DRUNTIMESRC rt/_stdio_msvc.d)
+* Source:    $(DRUNTIMESRC rt/_msvc.c)
 * Authors:   Rainer Schuetze
 */
 
@@ -156,3 +156,33 @@ int  _msvc_fileno(FILE* stream)
 {
     return stream->_file;
 }
+
+
+
+/**
+ * 32-bit x86 MS VC runtimes lack most single-precision math functions.
+ * Declare alternate implementations to be pulled in from msvc_math.c.
+ */
+#if defined _M_IX86
+
+DECLARE_ALTERNATE_NAME (acosf,  _msvc_acosf);
+DECLARE_ALTERNATE_NAME (asinf,  _msvc_asinf);
+DECLARE_ALTERNATE_NAME (atanf,  _msvc_atanf);
+DECLARE_ALTERNATE_NAME (atan2f, _msvc_atan2f);
+DECLARE_ALTERNATE_NAME (cosf,   _msvc_cosf);
+DECLARE_ALTERNATE_NAME (sinf,   _msvc_sinf);
+DECLARE_ALTERNATE_NAME (tanf,   _msvc_tanf);
+DECLARE_ALTERNATE_NAME (coshf,  _msvc_coshf);
+DECLARE_ALTERNATE_NAME (sinhf,  _msvc_sinhf);
+DECLARE_ALTERNATE_NAME (tanhf,  _msvc_tanhf);
+DECLARE_ALTERNATE_NAME (expf,   _msvc_expf);
+DECLARE_ALTERNATE_NAME (logf,   _msvc_logf);
+DECLARE_ALTERNATE_NAME (log10f, _msvc_log10f);
+DECLARE_ALTERNATE_NAME (powf,   _msvc_powf);
+DECLARE_ALTERNATE_NAME (sqrtf,  _msvc_sqrtf);
+DECLARE_ALTERNATE_NAME (ceilf,  _msvc_ceilf);
+DECLARE_ALTERNATE_NAME (floorf, _msvc_floorf);
+DECLARE_ALTERNATE_NAME (fmodf,  _msvc_fmodf);
+DECLARE_ALTERNATE_NAME (modff,  _msvc_modff);
+
+#endif // _M_IX86

--- a/src/rt/msvc_math.c
+++ b/src/rt/msvc_math.c
@@ -1,0 +1,52 @@
+/**
+* This module provides alternate implementations of single-precision math
+* functions missing in at least some 32-bit x86 MS VC runtimes
+*
+* Copyright: Copyright Digital Mars 2015.
+* License: Distributed under the
+*      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+*    (See accompanying file LICENSE)
+* Source:    $(DRUNTIMESRC rt/_msvc_math.c)
+* Authors:   Martin Kinkelin
+*/
+
+#if defined _M_IX86
+
+// Forward-declare double-precision version and implement single-precision
+// wrapper.
+#define ALT_IMPL(baseName) \
+    double baseName(double x); \
+    float _msvc_ ## baseName ## f(float x) { return (float)baseName(x); }
+#define ALT_IMPL2(baseName) \
+    double baseName(double x, double y); \
+    float _msvc_ ## baseName ## f(float x, float y) { return (float)baseName(x, y); }
+
+ALT_IMPL(acos);
+ALT_IMPL(asin);
+ALT_IMPL(atan);
+ALT_IMPL2(atan2);
+ALT_IMPL(cos);
+ALT_IMPL(sin);
+ALT_IMPL(tan);
+ALT_IMPL(cosh);
+ALT_IMPL(sinh);
+ALT_IMPL(tanh);
+ALT_IMPL(exp);
+ALT_IMPL(log);
+ALT_IMPL(log10);
+ALT_IMPL2(pow);
+ALT_IMPL(sqrt);
+ALT_IMPL(ceil);
+ALT_IMPL(floor);
+ALT_IMPL2(fmod);
+
+double modf(double value, double *iptr);
+float _msvc_modff(float value, float *iptr)
+{
+    double di;
+    float result = (float)modf(value, &di);
+    *iptr = (float)di;
+    return result;
+}
+
+#endif // _M_IX86

--- a/win64.mak
+++ b/win64.mak
@@ -43,8 +43,8 @@ $(mak\SRCS)
 # NOTE: a pre-compiled minit.obj has been provided in dmd for Win32 and
 #       minit.asm is not used by dmd for Linux
 
-OBJS= errno_c_$(MODEL).obj stdio_msvc_$(MODEL).obj
-OBJS_TO_DELETE= errno_c_$(MODEL).obj stdio_msvc_$(MODEL).obj
+OBJS= errno_c_$(MODEL).obj msvc_$(MODEL).obj msvc_math_$(MODEL).obj
+OBJS_TO_DELETE= errno_c_$(MODEL).obj msvc_$(MODEL).obj msvc_math_$(MODEL).obj
 
 ######################## Doc .html file generation ##############################
 
@@ -1141,8 +1141,11 @@ $(IMPDIR)\etc\linux\memoryerror.d : src\etc\linux\memoryerror.d
 errno_c_$(MODEL).obj : src\core\stdc\errno.c
 	$(CC) -c -Fo$@ $(CFLAGS) src\core\stdc\errno.c
 
-stdio_msvc_$(MODEL).obj : src\rt\stdio_msvc.c win64.mak
-	$(CC) -c -Fo$@ $(CFLAGS) src\rt\stdio_msvc.c
+msvc_$(MODEL).obj : src\rt\msvc.c win64.mak
+	$(CC) -c -Fo$@ $(CFLAGS) src\rt\msvc.c
+
+msvc_math_$(MODEL).obj : src\rt\msvc_math.c win64.mak
+	$(CC) -c -Fo$@ $(CFLAGS) src\rt\msvc_math.c
 
 
 src\rt\minit.obj : src\rt\minit.asm


### PR DESCRIPTION
The x86 runtime lacks most *f versions (asinf(), acosf() etc.), i.e., they are only inline-declared in the C headers (and use the 64-bit double version).
The available symbols apparently depend upon whether one's linking against the static or dynamic MS runtime (libcmt.lib vs. msvcrt.lib), and possibly upon the Visual Studio version too.

So provide alternate implementations here in druntime to prevent linker errors. I came up with these 19 missing functions about a year ago by inspecting the VS 2013 headers (these should be all inline-declared ones, iirc).

Pinging @rainers.