### PR TITLE
fix nightly builds

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -1175,7 +1175,8 @@ lib\win32\winspool.lib : def\winspool.def
 errno_c_$(MODEL).obj : src\core\stdc\errno.c
 	$(CC) -c -o$@ $(CFLAGS) src\core\stdc\errno.c
 
-src\rt\minit.obj : src\rt\minit.asm
+# only rebuild explicitly
+rebuild_minit_obj : src\rt\minit.asm
 	$(CC) -c $(CFLAGS) src\rt\minit.asm
 
 ################### gcstub generation #########################

--- a/win64.mak
+++ b/win64.mak
@@ -40,8 +40,6 @@ $(mak\SRCS)
 
 # NOTE: trace.d and cover.d are not necessary for a successful build
 #       as both are used for debugging features (profiling and coverage)
-# NOTE: a pre-compiled minit.obj has been provided in dmd for Win32 and
-#       minit.asm is not used by dmd for Linux
 
 OBJS= errno_c_$(MODEL).obj msvc_$(MODEL).obj msvc_math_$(MODEL).obj
 OBJS_TO_DELETE= errno_c_$(MODEL).obj msvc_$(MODEL).obj msvc_math_$(MODEL).obj
@@ -1149,10 +1147,6 @@ msvc_$(MODEL).obj : src\rt\msvc.c win64.mak
 
 msvc_math_$(MODEL).obj : src\rt\msvc_math.c win64.mak
 	$(CC) -c -Fo$@ $(CFLAGS) src\rt\msvc_math.c
-
-# only rebuild explicitly
-rebuild_minit_obj : src\rt\minit.asm
-	$(CC) -c $(CFLAGS) src\rt\minit.asm
 
 ################### gcstub generation #########################
 

--- a/win64.mak
+++ b/win64.mak
@@ -1150,8 +1150,8 @@ msvc_$(MODEL).obj : src\rt\msvc.c win64.mak
 msvc_math_$(MODEL).obj : src\rt\msvc_math.c win64.mak
 	$(CC) -c -Fo$@ $(CFLAGS) src\rt\msvc_math.c
 
-
-src\rt\minit.obj : src\rt\minit.asm
+# only rebuild explicitly
+rebuild_minit_obj : src\rt\minit.asm
 	$(CC) -c $(CFLAGS) src\rt\minit.asm
 
 ################### gcstub generation #########################


### PR DESCRIPTION
- build minit.obj explicitly
- fixes sporadic build failures caused by different timestamps after
  checkout
- requires to explicitly rebuild minit.obj, but we haven't touched the
  asm code since ages