### PR TITLE
Add bsf(ulong), bsr(ulong), and popcnt(ulong).

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -60,10 +60,9 @@ int bsf(size_t v) pure;
 /// ditto
 int bsf(ulong v) pure
 {
-    static if(size_t.sizeof == ulong.sizeof)
-        return bsf(cast(size_t)v);
-    else
-    static if(size_t.sizeof == uint.sizeof)
+    static if (size_t.sizeof == ulong.sizeof)
+        return bsf(cast(size_t) v);
+    else static if (size_t.sizeof == uint.sizeof)
     {
         const sv = Split64(v);
         return (sv.lo == 0)?
@@ -95,10 +94,9 @@ int bsr(size_t v) pure;
 /// ditto
 int bsr(ulong v) pure
 {
-    static if(size_t.sizeof == ulong.sizeof)
-        return bsr(cast(size_t)v);
-    else
-    static if(size_t.sizeof == uint.sizeof)
+    static if (size_t.sizeof == ulong.sizeof)
+        return bsr(cast(size_t) v);
+    else static if (size_t.sizeof == uint.sizeof)
     {
         const sv = Split64(v);
         return (sv.hi == 0)?
@@ -256,6 +254,126 @@ version (DigitalMars) version (AnyX86) @system // not pure
     uint outpl(uint port_address, uint value);
 }
 
+
+/**
+ *  Calculates the number of set bits in an integer.
+ */
+int popcnt(uint x) pure
+{
+    // Select the fastest method depending on the compiler and CPU architecture
+    version(LDC)
+    {
+        return _popcnt(x);
+    }
+    else
+    {
+        version(DigitalMars)
+        {
+            static if (is(typeof(_popcnt(uint.max))))
+            {
+                import core.cpuid;
+                if (hasPopcnt)
+                    return _popcnt(x);
+            }
+        }
+
+        return soft_popcnt!uint(x);
+    }
+}
+
+unittest
+{
+    assert( popcnt( 0 ) == 0 );
+    assert( popcnt( 7 ) == 3 );
+    assert( popcnt( 0xAA )== 4 );
+    assert( popcnt( 0x8421_1248 ) == 8 );
+    assert( popcnt( 0xFFFF_FFFF ) == 32 );
+    assert( popcnt( 0xCCCC_CCCC ) == 16 );
+    assert( popcnt( 0x7777_7777 ) == 24 );
+}
+
+/// ditto
+int popcnt(ulong x) pure
+{
+    // Select the fastest method depending on the compiler and CPU architecture
+    version(LDC)
+    {
+        return _popcnt(x);
+    }
+    else
+    {
+        import core.cpuid;
+
+        static if (size_t.sizeof == uint.sizeof)
+        {
+            const sx = Split64(x);
+            version(DigitalMars)
+            {
+                static if (is(typeof(_popcnt(uint.max))))
+                {
+                    if (hasPopcnt)
+                        return _popcnt(sx.lo) + _popcnt(sx.hi);
+                }
+            }
+
+            return soft_popcnt!uint(sx.lo) + soft_popcnt!uint(sx.hi);
+        }
+        else static if (size_t.sizeof == ulong.sizeof)
+        {
+            version(DigitalMars)
+            {
+                static if (is(typeof(_popcnt(ulong.max))))
+                {
+                    if (hasPopcnt)
+                        return _popcnt(x);
+                }
+            }
+
+            return soft_popcnt!ulong(x);
+        }
+        else
+            static assert(false);
+    }
+}
+
+unittest
+{
+    assert(popcnt(0uL) == 0);
+    assert(popcnt(1uL) == 1);
+    assert(popcnt((1uL << 32) - 1) == 32);
+    assert(popcnt(0x48_65_6C_6C_6F_3F_21_00uL) == 28);
+    assert(popcnt(ulong.max) == 64);
+}
+
+private int soft_popcnt(N)(N x) pure
+    if (is(N == uint) || is(N == ulong))
+{
+    // Avoid branches, and the potential for cache misses which
+    // could be incurred with a table lookup.
+
+    // We need to mask alternate bits to prevent the
+    // sum from overflowing.
+    // add neighbouring bits. Each bit is 0 or 1.
+    enum mask1 = cast(N) 0x5555_5555_5555_5555L;
+    x = x - ((x>>1) & mask1);
+    // now each two bits of x is a number 00,01 or 10.
+    // now add neighbouring pairs
+    enum mask2a = cast(N) 0xCCCC_CCCC_CCCC_CCCCL;
+    enum mask2b = cast(N) 0x3333_3333_3333_3333L;
+    x = ((x & mask2a)>>2) + (x & mask2b);
+    // now each nibble holds 0000-0100. Adding them won't
+    // overflow any more, so we don't need to mask any more
+
+    enum mask4 = cast(N) 0x0F0F_0F0F_0F0F_0F0FL;
+    x = (x + (x >> 4)) & mask4;
+
+    enum shiftbits = is(N == uint)? 24 : 56;
+    enum maskMul = cast(N) 0x0101_0101_0101_0101L;
+    x = (x * maskMul) >> shiftbits;
+
+    return cast(int) x;
+}
+
 version (DigitalMars) version (AnyX86)
 {
     /**
@@ -309,6 +427,7 @@ version (DigitalMars) version (AnyX86)
     }
 }
 
+
 /*************************************
  * Read/write value from/to the memory location indicated by ptr.
  *
@@ -360,70 +479,6 @@ void volatileStore(ulong * ptr, ulong  value);   /// ditto
         T r = volatileLoad(p);
         assert(r == u);
     }
-}
-
-
-/**
- *  Calculates the number of set bits in an integer.
- */
-int popcnt( uint x ) pure
-{
-    // Avoid branches, and the potential for cache misses which
-    // could be incurred with a table lookup.
-
-    // We need to mask alternate bits to prevent the
-    // sum from overflowing.
-    // add neighbouring bits. Each bit is 0 or 1.
-    x = x - ((x>>1) & 0x5555_5555);
-    // now each two bits of x is a number 00,01 or 10.
-    // now add neighbouring pairs
-    x = ((x&0xCCCC_CCCC)>>2) + (x&0x3333_3333);
-    // now each nibble holds 0000-0100. Adding them won't
-    // overflow any more, so we don't need to mask any more
-
-    // Now add the nibbles, then the bytes, then the words
-    // We still need to mask to prevent double-counting.
-    // Note that if we used a rotate instead of a shift, we
-    // wouldn't need the masks, and could just divide the sum
-    // by 8 to account for the double-counting.
-    // On some CPUs, it may be faster to perform a multiply.
-
-    x += (x>>4);
-    x &= 0x0F0F_0F0F;
-    x += (x>>8);
-    x &= 0x00FF_00FF;
-    x += (x>>16);
-    x &= 0xFFFF;
-    return x;
-}
-
-
-unittest
-{
-    assert( popcnt( 0 ) == 0 );
-    assert( popcnt( 7 ) == 3 );
-    assert( popcnt( 0xAA )== 4 );
-    assert( popcnt( 0x8421_1248 ) == 8 );
-    assert( popcnt( 0xFFFF_FFFF ) == 32 );
-    assert( popcnt( 0xCCCC_CCCC ) == 16 );
-    assert( popcnt( 0x7777_7777 ) == 24 );
-}
-
-/// ditto
-int popcnt(ulong x) pure
-{
-    // TODO: How to detect when _popcnt() is safe to use?
-    const sx = Split64(x);
-    return popcnt(sx.lo) + popcnt(sx.hi);
-}
-
-unittest
-{
-    assert(popcnt(0uL) == 0);
-    assert(popcnt(1uL) == 1);
-    assert(popcnt((1uL << 32) - 1) == 32);
-    assert(popcnt(0x48_65_6C_6C_6F_3F_21_00uL) == 28);
-    assert(popcnt(ulong.max) == 64);
 }
 
 


### PR DESCRIPTION
This PR adds `ulong` versions of `bsf()`, `bsr()`, and `popcnt()`. (It also fixes a small error in the `_popcnt()` docs.)

I use these `core.bitop` functions fairly often, and am always annoyed that the maximum bit-ness of the input depends on what architecture I'm compiling for; it makes using these ops from generic code painful.

There is no good reason for this, as even on 32-bit systems the 64-bit op can be trivially implemented in terms of a couple of calls to the 32-bit op.

**EDIT:** I have created a [companion PR for Phobos](https://github.com/D-Programming-Language/phobos/pull/3888). While working on it, I discovered two different private implementations of `bsr()` for `ulong`, one of which is bugged.