### PR TITLE
Dwarf EH: add _d_eh_swapContextDwarf

### DIFF
--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -150,6 +150,21 @@ extern(C) Throwable __dmd_begin_catch(_Unwind_Exception* exceptionObject)
     return o;
 }
 
+/****************************************
+ * Called when fibers switch contexts.
+ * Params:
+ *      newContext = stack to switch to
+ * Returns:
+ *      previous value of stack
+ */
+extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow
+{
+    auto old = ExceptionHeader.stack;
+    ExceptionHeader.stack = cast(ExceptionHeader*)newContext;
+    return old;
+}
+
+
 /*********************
  * Called by D code to throw an exception via
  * ---


### PR DESCRIPTION
Added function needed to swap contexts for fibers. For transitional porpoises, support both old and new eh functionality at the same time, detect which at runtime.

This is blocking https://github.com/D-Programming-Language/dmd/pull/5324