### PR TITLE
add indication of which test is being started

### DIFF
--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -29,6 +29,8 @@ bool tester()
         try
         {
             immutable t0 = MonoTime.currTime;
+            printf("STARTING %.*s\n",
+                cast(uint)name.length, name.ptr);
             fp();
             printf("%.3fs PASS %.*s %.*s\n",
                 (MonoTime.currTime - t0).total!"msecs" / 1000.0,


### PR DESCRIPTION
Because when a test crashes, I have no idea which one it was, because the logging only logs upon completion.