### PR TITLE
Add ability to clear AA of all elements

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -7,7 +7,8 @@ $(BUGSTITLE Library Changes,
 
 $(LI $(RELATIVE_LINK2 TypeInfo.initializer, `TypeInfo.init` has been renamed to
     `TypeInfo.initializer`.))
-)
+$(LI $(RELATIVE_LINK2 AA.clear, Associative array `clear` method to remove all
+    elements has been added.))
 )
 
 $(BUGSTITLE Library Changes,
@@ -26,6 +27,15 @@ $(LI $(LNAME2 TypeInfo.initializer, `TypeInfo.init` has been renamed to
         2.072.0 release, and is going to be `@disable`d with the 2.073.0
         release. Finally, the special casing is going to be removed with the
         2.074.0 release, so that the type property `init` takes over.
+    )
+)
+$(LI $(LNAME2 AA.clear, Associative array `clear` method to remove all
+    elements has been added.)
+
+    $(P One can now use `aa.clear()` to remove all elements from an
+        associative array. This allows one to remove all elements from all
+        references to the same array (setting to `null` just cleared the
+        reference, not removed the elements).
     )
 )
 )

--- a/changelog.dd
+++ b/changelog.dd
@@ -7,8 +7,8 @@ $(BUGSTITLE Library Changes,
 
 $(LI $(RELATIVE_LINK2 TypeInfo.initializer, `TypeInfo.init` has been renamed to
     `TypeInfo.initializer`.))
-$(LI $(RELATIVE_LINK2 AA.clear, Associative array `clear` method to remove all
-    elements has been added.))
+$(LI $(RELATIVE_LINK2 aa-clear, A `clear` method has been added to associative
+    arrays to remove all elements.))
 )
 
 $(BUGSTITLE Library Changes,
@@ -29,14 +29,21 @@ $(LI $(LNAME2 TypeInfo.initializer, `TypeInfo.init` has been renamed to
         2.074.0 release, so that the type property `init` takes over.
     )
 )
-$(LI $(LNAME2 AA.clear, Associative array `clear` method to remove all
-    elements has been added.)
+$(LI $(LNAME2 aa-clear, A `clear` method has been added to associative
+    arrays to remove all elements.)
 
     $(P One can now use `aa.clear()` to remove all elements from an
-        associative array. This allows one to remove all elements from all
-        references to the same array (setting to `null` just cleared the
-        reference, not removed the elements).
+        associative array. This allows removing all elements from all
+        references to the same array (setting to `null` just reset the
+        reference, but did not removed the elements from other references).
     )
+
+-------
+auto aa = ["first" : "entry", "second": "entry"];
+auto aa2 = aa1; // reference to the same AA
+aa.clear(); // still retains its current capacity for faster imports
+assert(aa2.length == 0); // other references affected
+-------
 )
 )
 

--- a/src/object.d
+++ b/src/object.d
@@ -1857,6 +1857,7 @@ extern (C)
     inout(void)[] _aaValues(inout void* p, in size_t keysize, in size_t valuesize, const TypeInfo tiValArray) pure nothrow;
     inout(void)[] _aaKeys(inout void* p, in size_t keysize, const TypeInfo tiKeyArray) pure nothrow;
     void* _aaRehash(void** pp, in TypeInfo keyti) pure nothrow;
+    void _aaClear(void* p) pure nothrow;
 
     // alias _dg_t = extern(D) int delegate(void*);
     // int _aaApply(void* aa, size_t keysize, _dg_t dg);
@@ -1889,6 +1890,16 @@ void* aaLiteral(Key, Value)(Key[] keys, Value[] values) @trusted pure
 }
 
 alias AssociativeArray(Key, Value) = Value[Key];
+
+void clear(T : Value[Key], Value, Key)(T aa)
+{
+    _aaClear(*cast(void **)&aa);
+}
+
+void clear(T : Value[Key], Value, Key)(T* aa)
+{
+    _aaClear(*cast(void **)aa);
+}
 
 T rehash(T : Value[Key], Value, Key)(T aa)
 {

--- a/src/object.d
+++ b/src/object.d
@@ -1893,12 +1893,12 @@ alias AssociativeArray(Key, Value) = Value[Key];
 
 void clear(T : Value[Key], Value, Key)(T aa)
 {
-    _aaClear(*cast(void **)&aa);
+    _aaClear(*cast(void **) &aa);
 }
 
 void clear(T : Value[Key], Value, Key)(T* aa)
 {
-    _aaClear(*cast(void **)aa);
+    _aaClear(*cast(void **) aa);
 }
 
 T rehash(T : Value[Key], Value, Key)(T aa)

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -142,17 +142,12 @@ private:
     {
         auto obuckets = buckets;
         buckets = allocBuckets(ndim);
-        auto newFirstUsed = cast(uint) ndim;
 
         foreach (ref b; obuckets[firstUsed .. $])
             if (b.filled)
-            {
-                auto x = findSlotInsert(b.hash);
-                newFirstUsed = min(newFirstUsed, cast(uint) (x - buckets.ptr));
-                *x = b;
-            }
+                *findSlotInsert(b.hash) = b;
 
-        firstUsed = newFirstUsed;
+        firstUsed = 0;
         used -= deleted;
         deleted = 0;
         GC.free(obuckets.ptr); // safe to free b/c impossible to reference

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -142,13 +142,13 @@ private:
     {
         auto obuckets = buckets;
         buckets = allocBuckets(ndim);
-        uint newFirstUsed = cast(uint)ndim;
+        auto newFirstUsed = cast(uint) ndim;
 
-        foreach (ref b; obuckets[firstUsed..$])
+        foreach (ref b; obuckets[firstUsed .. $])
             if (b.filled)
             {
                 auto x = findSlotInsert(b.hash);
-                newFirstUsed = min(newFirstUsed, cast(uint)(x - buckets.ptr));
+                newFirstUsed = min(newFirstUsed, cast(uint) (x - buckets.ptr));
                 *x = b;
             }
 
@@ -160,16 +160,16 @@ private:
 
     void clear() pure nothrow
     {
-        foreach(ref b; buckets[firstUsed..$])
+        foreach (ref b; buckets[firstUsed .. $])
         {
-            if(b.filled)
+            if (b.filled)
             {
                 b.hash = HASH_DELETED;
                 b.entry = null;
             }
         }
         deleted = used;
-        firstUsed = cast(uint)dim;
+        firstUsed = cast(uint) dim;
         resize(INIT_NUM_BUCKETS);
     }
 }
@@ -448,7 +448,7 @@ extern (C) bool _aaDelX(AA aa, in TypeInfo keyti, in void* pkey)
 /// Remove all elements from AA.
 extern (C) void _aaClear(AA aa) pure nothrow
 {
-    if(!aa.empty)
+    if (!aa.empty)
     {
         aa.impl.clear();
     }
@@ -967,7 +967,7 @@ pure nothrow unittest
 {
     int[int] aa;
     assert(aa.length == 0);
-    foreach(i; 0..100)
+    foreach (i; 0 .. 100)
         aa[i] = i * 2;
     assert(aa.length == 100);
     auto aa2 = aa;

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -155,17 +155,11 @@ private:
 
     void clear() pure nothrow
     {
-        foreach (ref b; buckets[firstUsed .. $])
-        {
-            if (b.filled)
-            {
-                b.hash = HASH_DELETED;
-                b.entry = null;
-            }
-        }
-        deleted = used;
+        import core.stdc.string : memset;
+        // clear all data, but don't change bucket array length
+        memset(&buckets[firstUsed], 0, (buckets.length - firstUsed) * Bucket.sizeof);
+        deleted = used = 0;
         firstUsed = cast(uint) dim;
-        resize(INIT_NUM_BUCKETS);
     }
 }
 


### PR DESCRIPTION
This is a reworking of #999 using new AA implementation.

Note, clear has been gone as a deprecated alias since [March 2015](https://github.com/D-Programming-Language/druntime/commit/fa624c472f2357e375d3b52eaa473dad709c725a).

I also changed firstUsed cache code to be more accurate.

@MartinNowak, I'm curious why you keep a running total of deleted elements (and flag them differently)? What purpose does this serve? It seems to make the code more complex than it needs to be.