### PR TITLE
Issue 15595 - Interface cast on collection may fail

### DIFF
--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -53,7 +53,11 @@ void* _d_interface_cast(void* p, ClassInfo c)
     if (!p)
         return null;
 
-    Interface* pi = **cast(Interface***) p;
+    Interface* pi;
+    if (auto pi_ = *cast(Interface***)p)
+        pi = *pi_;
+    if (!pi)
+        return null;
 
     debug(cast_) printf("\tpi.offset = %d\n", pi.offset);
     return _d_dynamic_cast(cast(Object)(p - pi.offset), c);


### PR DESCRIPTION
This solves an issue where the GC collection cycle would take out a vtable pointer before another destructor tried to access it when calling destroy() on the object. This covered 99.9% of the remaining causes of segmentation faults in my server and was unpredictable.