### PR TITLE
Optimize array cast for equivalence

### DIFF
--- a/src/rt/arraycast.d
+++ b/src/rt/arraycast.d
@@ -25,6 +25,7 @@ extern (C)
 @trusted nothrow
 void[] _d_arraycast(size_t tsize, size_t fsize, void[] a)
 {
+    if (tsize == fsize) return a;
     auto length = a.length;
 
     auto nbytes = length * fsize;


### PR DESCRIPTION
In web servers and crypto, there is frequent back-and-forth casting between ubyte[] and string. This created a bottleneck where perf gave this function a 7% sampling prevalence. After this optimization, it went down <1%.