### PR TITLE
There's no reason to hide what the makefile is doing

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -3,7 +3,7 @@
 #    pkg_add -r gmake
 # and then run as gmake rather than make.
 
-QUIET:=@
+QUIET:=
 
 include osmodel.mak
 


### PR DESCRIPTION
When the makefile fails, like it does here:

https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=1929728&isPull=true

it's really hard to figure out what was being executed when it went wrong when in quiet mode. I have no idea where this desire to hide what commands are being executed comes from.