### PR TITLE
essential code should not be in assert's

### DIFF
--- a/test/shared/src/finalize.d
+++ b/test/shared/src/finalize.d
@@ -28,6 +28,7 @@ extern (C) alias SetFinalizeCounter = void function(shared(size_t*));
 
 void main(string[] args)
 {
+    printf("STARTING finalize\n");
     auto name = args[0];
     assert(name[$-9 .. $] == "/finalize");
     name = name[0 .. $-8] ~ "lib.so";
@@ -47,8 +48,14 @@ void main(string[] args)
     thr.start();
     thr.join();
 
-    assert(Runtime.unloadLibrary(h));
-    assert(finalizeCounter == 4);
-    assert(nf1._finalizeCounter == 0);
-    assert(nf2._finalizeCounter == 0);
+    auto r = Runtime.unloadLibrary(h);
+    if (!r)
+        assert(0);
+    if (finalizeCounter != 4)
+        assert(0);
+    if (nf1._finalizeCounter)
+        assert(0);
+    if (nf2._finalizeCounter)
+        assert(0);
+    printf("PASS finalize\n");
 }


### PR DESCRIPTION
The call to `unloadLibrary()` should not be in an assert, because when compiled with `-release` it gets elided.

This appears to be blocking https://github.com/D-Programming-Language/dmd/pull/5359 so please pull.