### PR TITLE
Remove pragma(inline, true) in runLocked function template.

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -347,7 +347,6 @@ struct GC
 
     auto runLocked(alias func, alias time, alias count, Args...)(auto ref Args args)
     {
-        debug(PROFILE_API) {} else pragma(inline, true);
         debug(PROFILE_API) immutable tm = (GC.config.profile > 1 ? currTime.ticks : 0);
         gcLock.lock();
         debug(PROFILE_API) immutable tm2 = (GC.config.profile > 1 ? currTime.ticks : 0);


### PR DESCRIPTION
druntime is compiled with -inline by default, so it's needlessly limited by the compiler's inlining capability. Removing it would have no problem.

From: https://github.com/D-Programming-Language/druntime/pull/1491#issuecomment-181357376