### PR TITLE
Optimize GC mark phase implementation

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -2004,7 +2004,7 @@ struct Gcx
 
         // let dmd allocate a register for this.pools
         auto pools = pooltable.pools;
-        const npools = pooltable.npools;
+        const highpool = pooltable.npools - 1;
         const minAddr = pooltable.minAddr;
         const maxAddr = pooltable.maxAddr;
 
@@ -2020,10 +2020,10 @@ struct Gcx
                     continue;
 
                 Pool* pool = void;
-                if (npools > 1)
+                if (npools > 0)
                 {
                     size_t low = 0;
-                    size_t high = npools - 1;
+                    size_t high = highpool;
                     while (true)
                     {
                         size_t mid = (low + high) >> 1;

--- a/src/gc/pooltable.d
+++ b/src/gc/pooltable.d
@@ -158,7 +158,7 @@ nothrow:
     @property const(byte)* minAddr() pure const { return _minAddr; }
     @property const(byte)* maxAddr() pure const { return _maxAddr; }
 
-private:
+package:
     Pool** pools;
     size_t npools;
     byte* _minAddr, _maxAddr;


### PR DESCRIPTION
There are some low-hanging micro optimizations for the GC.

This is an average 24.7% reduction in running time for the mark phase on my test-case. The speed up should translate well for other cases as it just improves the throughput by minimizing branching and inlining the pool search.

This is my test program:

```d
import core.memory;
enum Prime = cast(uint)3147655439;
void main() {
    uint start = 1000;
    void* lptr = null;
    GC.collect();
    foreach (i; 0.. 2_000_000) {
        auto size = cast(uint)(start++ * Prime) % (8 << 10);
        if (size < 8) size = 8;
        auto ptr = GC.malloc(size);
        if (lptr) *cast(void**)lptr = ptr;
        lptr = ptr;
    }
    lptr = null;
    GC.collect();
}
```

Timings were computed over 20 runs of this program with and without the patch, passing `"--DRT-gcopt=profile:1"` and recording the mark phase time.

*this patch*
mean: 295.15ms
stdev: 42.65

*current master*
mean: 392.00ms
stdev: 31.19