### PR TITLE
Issue 15680 - TypeInfo broken for typeof(null)

### DIFF
--- a/mak/SRCS
+++ b/mak/SRCS
@@ -330,6 +330,7 @@ SRCS=\
 	src\rt\typeinfo\ti_int.d \
 	src\rt\typeinfo\ti_ireal.d \
 	src\rt\typeinfo\ti_long.d \
+	src\rt\typeinfo\ti_n.d \
 	src\rt\typeinfo\ti_ptr.d \
 	src\rt\typeinfo\ti_real.d \
 	src\rt\typeinfo\ti_short.d \

--- a/src/rt/typeinfo/ti_n.d
+++ b/src/rt/typeinfo/ti_n.d
@@ -1,0 +1,58 @@
+/**
+ * TypeInfo support code.
+ *
+ * Copyright: Copyright Digital Mars 2016.
+ * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Kenji Hara
+ */
+
+/*          Copyright Digital Mars 2016.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+module rt.typeinfo.ti_n;
+
+// typeof(null)
+
+class TypeInfo_n : TypeInfo
+{
+    override string toString() const @safe { return "typeof(null)"; }
+
+    override size_t getHash(in void* p) const
+    {
+        return 0;
+    }
+
+    override bool equals(in void* p1, in void* p2) const @trusted
+    {
+        //return *cast(typeof(null)*)p1 is *cast(typeof(null)*)p2;
+        return true;
+    }
+
+    override int compare(in void* p1, in void* p2) const @trusted
+    {
+        //if (*cast(int*) p1 < *cast(int*) p2)
+        //    return -1;
+        //else if (*cast(int*) p1 > *cast(int*) p2)
+        //    return 1;
+        return 0;
+    }
+
+    override @property size_t tsize() const
+    {
+        return typeof(null).sizeof;
+    }
+
+    override const(void)[] initializer() const @trusted
+    {
+        return (cast(void*)null)[0 .. typeof(null).sizeof];
+    }
+
+    override void swap(void *p1, void *p2) const @trusted
+    {
+        //auto t = *cast(typeof(null)*)p1;
+        //*cast(typeof(null)*)p1 = *cast(typeof(null)*)p2;
+        //*cast(typeof(null)*)p2 = t;
+    }
+}


### PR DESCRIPTION
Add `TypeInfo_n` for `typeid(typeof(null))`.

Needs to be merged before dmd codegen fix #5459.