### PR TITLE
Fix epoll_event for non-X86 architectures

### DIFF
--- a/src/core/sys/linux/epoll.d
+++ b/src/core/sys/linux/epoll.d
@@ -45,11 +45,35 @@ enum
     EPOLL_CTL_MOD = 3, // Change file descriptor epoll_event structure.
 }
 
-align(1) struct epoll_event
+version (X86)
 {
-align(1):
-    uint events;
-    epoll_data_t data;
+    align(1) struct epoll_event
+    {
+    align(1):
+        uint events;
+        epoll_data_t data;
+    }
+}
+else version (X86_64)
+{
+    align(1) struct epoll_event
+    {
+    align(1):
+        uint events;
+        epoll_data_t data;
+    }
+}
+else version (ARM)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
+else
+{
+    static assert(false, "Platform not supported");
 }
 
 union epoll_data_t


### PR DESCRIPTION
X86 is the only architecture where epoll_event is actually packed. All other architectures define epoll_event as a normal struct:
http://code.metager.de/source/search?q=__EPOLL_PACKED&path=%2Fgnu%2Fglibc%2F&project=gnu
See also: http://bugzilla.gdcproject.org/show_bug.cgi?id=214