### PR TITLE
use timelimit to kill deadlocked tests

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -97,6 +97,9 @@ LINKDL=$(if $(findstring $(OS),linux),-L-ldl,)
 
 MAKEFILE = $(firstword $(MAKEFILE_LIST))
 
+# use timelimit to avoid deadlocks if available
+TIMELIMIT:=$(if $(shell which timelimit 2>/dev/null || true),timelimit -t 10 ,)
+
 ######################## All of'em ##############################
 
 ifneq (,$(SHARED))
@@ -239,7 +242,7 @@ $(ROOT)/unittest/% : $(ROOT)/unittest/test_runner
 # make the file very old so it builds and runs again if it fails
 	@touch -t 197001230123 $@
 # run unittest in its own directory
-	$(QUIET)$(RUN) $< $(call moduleName,$*)
+	$(QUIET)$(TIMELIMIT)$< $(call moduleName,$*)
 # succeeded, render the file new again
 	@touch $@
 
@@ -248,7 +251,8 @@ test/shared/.run: $(DRUNTIMESO)
 
 test/%/.run: test/%/Makefile
 	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) DMD=$(abspath $(DMD)) BUILD=$(BUILD) \
-		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) QUIET=$(QUIET) LINKDL=$(LINKDL)
+		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) LINKDL=$(LINKDL) \
+		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)'
 
 #################### test for undesired white spaces ##########################
 MANIFEST = $(shell git ls-tree --name-only -r HEAD)

--- a/test/common.mak
+++ b/test/common.mak
@@ -5,8 +5,9 @@ BUILD:=
 DMD:=
 DRUNTIME:=
 DRUNTIMESO:=
-QUIET:=
 LINKDL:=
+QUIET:=
+TIMELIMIT:=
 LDL:=$(subst -L,,$(LINKDL)) # -ldl
 
 SRC:=src

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -16,7 +16,7 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
 $(ROOT)/line_trace.done: $(ROOT)/line_trace
 	@echo Testing line_trace
-	$(QUIET)$(ROOT)/line_trace $(RUN_ARGS) > $(ROOT)/line_trace.output
+	$(QUIET)$(TIMELIMIT)$(ROOT)/line_trace $(RUN_ARGS) > $(ROOT)/line_trace.output
 	$(QUIET)$(SED) "s/\[0x[0-9a-f]*\]/\[ADDR\]/g" $(ROOT)/line_trace.output | $(DIFF) line_trace.exp -
 	@rm -f $(ROOT)/line_trace.output
 	@touch $@
@@ -26,7 +26,7 @@ $(ROOT)/unittest_assert.done: STDERR_EXP="unittest_assert msg"
 $(ROOT)/invalid_memory_operation.done: STDERR_EXP="InvalidMemoryOperationError"
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	$(QUIET)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
 	@touch $@
 
 $(ROOT)/unittest_assert: DFLAGS+=-unittest

--- a/test/init_fini/Makefile
+++ b/test/init_fini/Makefile
@@ -7,7 +7,7 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS)
 	@touch $@
 
 $(ROOT)/%: $(SRC)/%.d

--- a/test/profile/Makefile
+++ b/test/profile/Makefile
@@ -12,7 +12,7 @@ $(ROOT)/profile.done: DFLAGS+=-profile
 $(ROOT)/profile.done: $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	@rm -f $(ROOT)/mytrace.log $(ROOT)/mytrace.def
-	$(QUIET)$(ROOT)/$* $(ROOT)/mytrace.log $(ROOT)/mytrace.def
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(ROOT)/mytrace.log $(ROOT)/mytrace.def
 	$(QUIET)$(GREP) -q '1 .*_Dmain' $(ROOT)/mytrace.log
 	$(QUIET)$(GREP) -q '1000 .*uint profile.foo(uint)' $(ROOT)/mytrace.log
 	$(QUIET)$(DIFF) mytrace.def.exp $(ROOT)/mytrace.def
@@ -22,7 +22,7 @@ $(ROOT)/profilegc.done: DFLAGS+=-profile=gc
 $(ROOT)/profilegc.done: $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	@rm -f $(ROOT)/myprofilegc.log
-	$(QUIET)$(ROOT)/$* $(ROOT)/myprofilegc.log
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(ROOT)/myprofilegc.log
 	$(QUIET)$(DIFF) myprofilegc.log.exp $(ROOT)/myprofilegc.log
 	@touch $@
 
@@ -30,7 +30,7 @@ $(ROOT)/both.done: DFLAGS+=-profile -profile=gc
 $(ROOT)/both.done: $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	@rm -f $(ROOT)/both.log $(ROOT)/both.def $(ROOT)/bothgc.log
-	$(QUIET)$(ROOT)/$* $(ROOT)/both.log $(ROOT)/both.def $(ROOT)/bothgc.log
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(ROOT)/both.log $(ROOT)/both.def $(ROOT)/bothgc.log
 	$(QUIET)$(GREP) -q '1 .*_Dmain' $(ROOT)/both.log
 	$(QUIET)$(GREP) -q '1000 .*both.Num\* both.foo(uint)' $(ROOT)/both.log
 	$(QUIET)$(DIFF) both.def.exp $(ROOT)/both.def

--- a/test/shared/Makefile
+++ b/test/shared/Makefile
@@ -13,12 +13,12 @@ $(ROOT)/loadDR.done $(ROOT)/host.done: RUN_ARGS:=$(DRUNTIMESO)
 
 $(ROOT)/%_mod_collision.done: $(ROOT)/%_mod_collision
 	@echo Testing $*_mod_collision
-	$(QUIET)($< $(RUN_ARGS) 2>&1 || true) | grep -qF 'already defined'
+	$(QUIET)($(TIMELIMIT)$< $(RUN_ARGS) 2>&1 || true) | grep -qF 'already defined'
 	@touch $@
 
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	$(QUIET)$< $(RUN_ARGS)
+	$(QUIET)$(TIMELIMIT)$< $(RUN_ARGS)
 	@touch $@
 
 $(ROOT)/link: $(SRC)/link.d $(ROOT)/lib.so $(DRUNTIMESO)


### PR DESCRIPTION
- restrict any test to 10s
- don't trigger the 1h timeout for the auto-tester
- get a make error message w/ a specific test on timeout failure
- the timelimit program is used b/c the auto-tester already relies on it