### PR TITLE
Add missing epoll_event structures.

### DIFF
--- a/src/core/sys/linux/epoll.d
+++ b/src/core/sys/linux/epoll.d
@@ -71,6 +71,46 @@ else version (ARM)
         epoll_data_t data;
     }
 }
+else version (AArch64)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
+else version (PPC)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
+else version (PPC64)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
+else version (MIPS64)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
+else version (SystemZ)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
 else
 {
     static assert(false, "Platform not supported");


### PR DESCRIPTION
These are most of the missing definitions. I don't have the MIPS and SPARC
definitions at hand.