### PR TITLE
remove the pointless STARTING output during testing

### DIFF
--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -29,8 +29,6 @@ bool tester()
         try
         {
             immutable t0 = MonoTime.currTime;
-            printf("STARTING %.*s\n",
-                cast(uint)name.length, name.ptr);
             fp();
             printf("%.3fs PASS %.*s %.*s\n",
                 (MonoTime.currTime - t0).total!"msecs" / 1000.0,


### PR DESCRIPTION
- we now have make non-quiet by default and apply timelimit
  to each test so it's easy to figure out deadlocked tests
- with parallel make it wasn't easily possible to see which
  STARTING/PASS lines belong together anyhow