### PR TITLE
core.math: Add unit test for 128bit reals.

### DIFF
--- a/src/core/math.d
+++ b/src/core/math.d
@@ -100,7 +100,12 @@ extern (C) real rndtonl(real x);
 real ldexp(real n, int exp) @safe pure nothrow;    /* intrinsic */
 
 unittest {
-    static if (real.mant_dig == 64)
+    static if (real.mant_dig == 113)
+    {
+        assert(ldexp(1, -16384) == 0x1p-16384L);
+        assert(ldexp(1, -16382) == 0x1p-16382L);
+    }
+    else static if (real.mant_dig == 64)
     {
         assert(ldexp(1, -16384) == 0x1p-16384L);
         assert(ldexp(1, -16382) == 0x1p-16382L);
@@ -112,7 +117,7 @@ unittest {
         assert(ldexp(1, -1021) == 0x1p-1021L);
     }
     else
-        assert(false, "Only 80bit and 64bit reals expected here");
+        assert(false, "Only 128bit, 80bit and 64bit reals expected here");
 }
 
 /*******************************


### PR DESCRIPTION
Required for AArch64 port.