### PR TITLE
Add POSIX.1-2008 utimensat/futimens

### DIFF
--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -258,6 +258,9 @@ version( CRuntime_Glibc )
         int   creat(in char*, mode_t);
         int   open(in char*, int, ...);
     }
+
+    enum AT_SYMLINK_NOFOLLOW = 0x100;
+    enum AT_FDCWD = -100;
 }
 else version( OSX )
 {
@@ -366,6 +369,9 @@ else version( FreeBSD )
 
     int creat(in char*, mode_t);
     int open(in char*, int, ...);
+
+    enum AT_SYMLINK_NOFOLLOW = 0x200;
+    enum AT_FDCWD = -100;
 }
 else version (Solaris)
 {

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -629,6 +629,13 @@ version( CRuntime_Glibc )
         extern bool S_TYPEISSEM( stat_t* buf ) { return false; }
         extern bool S_TYPEISSHM( stat_t* buf ) { return false; }
     }
+
+    enum UTIME_NOW = 0x3fffffff;
+    enum UTIME_OMIT = 0x3ffffffe;
+
+    int utimensat(int dirfd, const char *pathname,
+        ref const(timespec)[2] times, int flags);
+    int futimens(int fd, ref const(timespec)[2] times);
 }
 else version( OSX )
 {
@@ -776,6 +783,17 @@ else version( FreeBSD )
     extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
     extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
     extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+
+    enum UTIME_NOW = -1;
+    enum UTIME_OMIT = -2;
+
+    // Since FreeBSD 11:
+    version (none)
+    {
+        int utimensat(int dirfd, const char *pathname,
+            ref const(timespec)[2] times, int flags);
+        int futimens(int fd, ref const(timespec)[2] times);
+    }
 }
 else version (Solaris)
 {


### PR DESCRIPTION
For https://github.com/D-Programming-Language/phobos/pull/4089

Linux only for now.

FreeBSD will support it in the next major release:
https://github.com/freebsd/freebsd/commit/67db24d0f2b81a222335fe5bb13977ef0c2258a9

Solaris seems to support it according to their documentation, but I can't test it or get the constant values.