### PR TITLE
fix Issue 15822 - InvalidMemoryOperationError when calling GC.removeRange/Root from a finalizer

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -9,6 +9,7 @@ $(LI $(RELATIVE_LINK2 aa-clear, A `clear` method has been added to associative
     arrays to remove all elements.))
 $(LI $(RELATIVE_LINK2 spinlock, The GC now uses a spinlock instead of a recursive mutex.))
 $(LI Calls to $(NCXREF memory, GC.free) are now ignored during finalization instead of throwing an InvalidMemoryOperationError, see $(BUGZILLA 15353).)
+$(LI $(NCXREF memory, GC.addRoot) and $(NCXREF memory, GC.addRange) now use a separate lock.)
 )
 
 $(BUGSTITLE Library Changes,


### PR DESCRIPTION
- use separate locks for GC.add/removeRange/Root
- avoids GC.lock contention for manual memory management