### PR TITLE
GC: remove condition that is never false

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -2020,29 +2020,21 @@ struct Gcx
                     continue;
 
                 Pool* pool = void;
-                if (npools > 0)
+                size_t low = 0;
+                size_t high = highpool;
+                while (true)
                 {
-                    size_t low = 0;
-                    size_t high = highpool;
-                    while (true)
-                    {
-                        size_t mid = (low + high) >> 1;
-                        pool = pools[mid];
-                        if (p < pool.baseAddr)
-                            high = mid - 1;
-                        else if (p >= pool.topAddr)
-                            low = mid + 1;
-                        else break;
+                    size_t mid = (low + high) >> 1;
+                    pool = pools[mid];
+                    if (p < pool.baseAddr)
+                        high = mid - 1;
+                    else if (p >= pool.topAddr)
+                        low = mid + 1;
+                    else break;
 
-                        if (low > high)
-                            continue Lnext;
-                    }
+                    if (low > high)
+                        continue Lnext;
                 }
-                else
-                {
-                    pool = pools[0];
-                }
-
                 size_t offset = cast(size_t)(p - pool.baseAddr);
                 size_t biti = void;
                 size_t pn = offset / PAGESIZE;


### PR DESCRIPTION
The condition should have been `if (npools > 1)` but I removed it because we should not optimize for the unlikely state that the application is using less than 1MB of memory. Instead this improves the situation when more moemory is used and scan speed matters more.