### PR TITLE
core.math: Add unit test for ldexp()

### DIFF
--- a/src/core/math.d
+++ b/src/core/math.d
@@ -105,6 +105,12 @@ unittest {
         assert(ldexp(1, -16384) == 0x1p-16384L);
         assert(ldexp(1, -16382) == 0x1p-16382L);
     }
+    else static if (real.mant_dig == 106)
+    {
+        assert(ldexp(1,  1023) == 0x1p1023L);
+        assert(ldexp(1, -1022) == 0x1p-1022L);
+        assert(ldexp(1, -1021) == 0x1p-1021L);
+    }
     else static if (real.mant_dig == 64)
     {
         assert(ldexp(1, -16384) == 0x1p-16384L);


### PR DESCRIPTION
This PR adds a unit test for the `ldexp()` function using the IBM
extended (double double) format. This format uses two doubles.
The exponent range is the same as the one of the double type.