### PR TITLE
Fix Issue 1180 - the GC failes to handle large allocation requests propperly 

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -1788,6 +1788,8 @@ struct Gcx
         LargeObjectPool* pool;
         size_t pn;
         immutable npages = (size + PAGESIZE - 1) / PAGESIZE;
+        if (npages == 0)
+            onOutOfMemoryErrorNoGC(); // size just below size_t.max requested
 
         bool tryAlloc() nothrow
         {

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -3302,6 +3302,19 @@ unittest // bugzilla 15822
     GC.collect();
 }
 
+unittest // bugzilla 1180
+{
+    import core.exception;
+    try
+    {
+        size_t x = size_t.max - 100;
+        byte[] big_buf = new byte[x];
+    }
+    catch(OutOfMemoryError)
+    {
+    }
+}
+
 /* ============================ SENTINEL =============================== */
 
 


### PR DESCRIPTION
report out-of-memory for allocation a bit below size_t.max

even though reported as a regression, this doesn't seem like anything new, so it might not be necessary to merge into stable.