### PR TITLE
fix Ddoc header comments in rt.array*

### DIFF
--- a/src/rt/arrayassign.d
+++ b/src/rt/arrayassign.d
@@ -1,16 +1,14 @@
 /**
  * Implementation of array assignment support routines.
  *
- * Copyright: Copyright Digital Mars 2000 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ *
+ * Copyright: Copyright Digital Mars 2010 - 2016.
+ * License:   Distributed under the
+ *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, Kenji Hara
+ * Source:    $(DRUNTIMESRC src/rt/_arrayassign.d)
  */
 
-/*          Copyright Digital Mars 2000 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module rt.arrayassign;
 
 private

--- a/src/rt/arraybyte.d
+++ b/src/rt/arraybyte.d
@@ -2,17 +2,14 @@
  * Contains SSE2 and MMX versions of certain operations for char, byte, and
  * ubyte ('a', 'g' and 'h' suffixes).
  *
- * Copyright: Copyright Digital Mars 2008 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Copyright: Copyright Digital Mars 2008 - 2016.
+ * License:   Distributed under the
+ *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, based on code originally written by Burton Radons,
  *            Brian Schott (64-bit operations)
+ * Source:    $(DRUNTIMESRC src/rt/_arraybyte.d)
  */
 
-/*          Copyright Digital Mars 2008 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module rt.arraybyte;
 
 import core.cpuid;

--- a/src/rt/arraycast.d
+++ b/src/rt/arraycast.d
@@ -1,16 +1,13 @@
 /**
  * Implementation of array cast support routines.
  *
- * Copyright: Copyright Digital Mars 2004 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Copyright: Copyright Digital Mars 2004 - 2016.
+ * License:   Distributed under the
+ *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, Sean Kelly
+ * Source:    $(DRUNTIMESRC src/rt/_arraycast.d)
  */
 
-/*          Copyright Digital Mars 2004 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module rt.arraycast;
 
 /******************************************

--- a/src/rt/arraycat.d
+++ b/src/rt/arraycat.d
@@ -1,16 +1,13 @@
 /**
  * Implementation of array copy support routines.
  *
- * Copyright: Copyright Digital Mars 2004 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Copyright: Copyright Digital Mars 2004 - 2016.
+ * License:   Distributed under the
+ *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, Sean Kelly
+ * Source:    $(DRUNTIMESRC src/rt/_arraycat.d)
  */
 
-/*          Copyright Digital Mars 2004 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module rt.arraycat;
 
 private

--- a/src/rt/arraydouble.d
+++ b/src/rt/arraydouble.d
@@ -1,17 +1,14 @@
 /**
  * Contains SSE2 and MMX versions of certain operations for double.
  *
- * Copyright: Copyright Digital Mars 2008 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Copyright: Copyright Digital Mars 2008 - 2016.
+ * License:   Distributed under the
+ *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, based on code originally written by Burton Radons;
  *            Jim Crapuchettes (64 bit SSE code)
+ * Source:    $(DRUNTIMESRC src/rt/_arraydouble.d)
  */
 
-/*          Copyright Digital Mars 2008 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module rt.arraydouble;
 
 // debug=PRINTF;

--- a/src/rt/arrayfloat.d
+++ b/src/rt/arrayfloat.d
@@ -1,16 +1,13 @@
 /**
  * Contains SSE2 and MMX versions of certain operations for float.
  *
- * Copyright: Copyright Digital Mars 2008 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Copyright: Copyright Digital Mars 2008 - 2016.
+ * License:   Distributed under the
+ *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, based on code originally written by Burton Radons
+ * Source:    $(DRUNTIMESRC src/rt/_arrayfloat.d)
  */
 
-/*          Copyright Digital Mars 2008 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module rt.arrayfloat;
 
 // debug=PRINTF

--- a/src/rt/arrayint.d
+++ b/src/rt/arrayint.d
@@ -2,16 +2,13 @@
  * Contains SSE/MMX versions of certain operations for dchar, int, and uint ('w',
  * 'i' and 'k' suffixes).
  *
- * Copyright: Copyright Digital Mars 2008 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Copyright: Copyright Digital Mars 2008 - 2016.
+ * License:   Distributed under the
+ *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, based on code originally written by Burton Radons
+ * Source:    $(DRUNTIMESRC src/rt/_arrayint.d)
  */
 
-/*          Copyright Digital Mars 2008 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module rt.arrayint;
 
 // debug=PRINTF

--- a/src/rt/arrayreal.d
+++ b/src/rt/arrayreal.d
@@ -1,16 +1,13 @@
 /**
  * Contains SSE2 and MMX versions of certain operations for real.
  *
- * Copyright: Copyright Digital Mars 2008 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Copyright: Copyright Digital Mars 2008 - 2016.
+ * License:   Distributed under the
+ *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, based on code originally written by Burton Radons
+ * Source:    $(DRUNTIMESRC src/rt/_arrayreal.d)
  */
 
-/*          Copyright Digital Mars 2008 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module rt.arrayreal;
 
 // debug=PRINTF

--- a/src/rt/arrayshort.d
+++ b/src/rt/arrayshort.d
@@ -2,16 +2,13 @@
  * Contains SSE2 and MMX versions of certain operations for wchar, short,
  * and ushort ('u', 's' and 't' suffixes).
  *
- * Copyright: Copyright Digital Mars 2008 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Copyright: Copyright Digital Mars 2008 - 2016.
+ * License:   Distributed under the
+ *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, based on code originally written by Burton Radons
+ * Source:    $(DRUNTIMESRC src/rt/_arrayshort.d)
  */
 
-/*          Copyright Digital Mars 2008 - 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module rt.arrayshort;
 
 // debug=PRINTF


### PR DESCRIPTION
All were missing `Source:` tags, removed redundant text.

All are subtly different in terms of Author, Copyright date, Source link, and description. Please double check for any copy/pasta errors!